### PR TITLE
fix apphttphealthy webhhok host and fix miss mean latency

### DIFF
--- a/pkg/loadRequest/loadDns/dns_reporter.go
+++ b/pkg/loadRequest/loadDns/dns_reporter.go
@@ -37,15 +37,16 @@ type report struct {
 	average  float64
 	tps      float64
 
-	results      chan *result
-	done         chan bool
-	total        time.Duration
-	errorDist    map[string]int
-	lats         []float32
-	totalCount   int64
-	successCount int64
-	failedCount  int64
-	ReplyCode    map[string]int
+	results        chan *result
+	done           chan bool
+	total          time.Duration
+	errorDist      map[string]int
+	lats           []float32
+	totalLatencies float32
+	totalCount     int64
+	successCount   int64
+	failedCount    int64
+	ReplyCode      map[string]int
 }
 
 func newReport(results chan *result, enableLatencyMetric bool) *report {
@@ -70,6 +71,8 @@ func runReporter(r *report) {
 			r.avgTotal += res.duration.Seconds()
 			if r.enableLatencyMetric {
 				r.lats = append(r.lats, float32(res.duration.Milliseconds()))
+			} else {
+				r.totalLatencies += float32(res.duration.Milliseconds())
 			}
 			rcodeStr := dns.RcodeToString[res.msg.Rcode]
 			r.ReplyCode[rcodeStr]++

--- a/pkg/loadRequest/loadDns/dns_requester.go
+++ b/pkg/loadRequest/loadDns/dns_requester.go
@@ -185,6 +185,8 @@ func (b *Work) AggregateMetric() *v1beta1.DNSMetrics {
 
 		t, _ = stats.Percentile(b.report.lats, 99)
 		latency.P99 = t
+	} else {
+		latency.Mean = b.report.totalLatencies / float32(b.report.totalCount)
 	}
 
 	metric := &v1beta1.DNSMetrics{

--- a/pkg/loadRequest/loadHttp/http_reporter.go
+++ b/pkg/loadRequest/loadHttp/http_reporter.go
@@ -37,12 +37,13 @@ type report struct {
 	results chan *result
 	done    chan bool
 
-	total       time.Duration
-	statusCodes map[int]int
-	errorDist   map[string]int
-	latencies   []float32
-	sizeTotal   int64
-	totalCount  int64
+	total          time.Duration
+	statusCodes    map[int]int
+	errorDist      map[string]int
+	latencies      []float32
+	totalLatencies float32
+	sizeTotal      int64
+	totalCount     int64
 }
 
 func newReport(results chan *result, enableLatencyMetric bool) *report {
@@ -66,6 +67,8 @@ func runReporter(r *report) {
 		} else {
 			if r.enableLatencyMetric {
 				r.latencies = append(r.latencies, float32(res.duration.Milliseconds()))
+			} else {
+				r.totalLatencies += float32(res.duration.Milliseconds())
 			}
 			if res.contentLength > 0 {
 				r.sizeTotal += res.contentLength

--- a/pkg/loadRequest/loadHttp/http_requester.go
+++ b/pkg/loadRequest/loadHttp/http_requester.go
@@ -349,6 +349,8 @@ func (b *Work) AggregateMetric() *v1beta1.HttpMetrics {
 
 		t, _ = stats.Percentile(b.report.latencies, 99)
 		latency.P99 = t
+	} else {
+		latency.Mean = b.report.totalLatencies / float32(b.report.totalCount)
 	}
 
 	var errNum int64

--- a/pkg/pluginManager/tools/tools.go
+++ b/pkg/pluginManager/tools/tools.go
@@ -76,12 +76,11 @@ func ValidataAppHttpHealthyHost(r *crd.AppHttpHealthy) error {
 	// protocol
 	protoclHttp := strings.Contains(r.Spec.Target.Host, "http")
 	protoclHttps := strings.Contains(r.Spec.Target.Host, "https")
-
 	var ip string
-	if protoclHttp {
-		ip = r.Spec.Target.Host[len("http://"):]
-	} else if protoclHttps {
+	if protoclHttps {
 		ip = r.Spec.Target.Host[len("https://"):]
+	} else if protoclHttp {
+		ip = r.Spec.Target.Host[len("http://"):]
 	} else {
 		ip = r.Spec.Target.Host
 	}

--- a/test/e2e/apphttphealth/apphttphealth_test.go
+++ b/test/e2e/apphttphealth/apphttphealth_test.go
@@ -294,7 +294,6 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		} else {
 			target.Host = fmt.Sprintf("https://%s:%d", testSvcIP, httpsPort)
 		}
-
 		target.TlsSecretName = &common.TlsClientName
 		target.TlsSecretNamespace = &testAppNamespace
 		appHttpHealth.Spec.Target = target
@@ -349,7 +348,6 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		} else {
 			target.Host = fmt.Sprintf("http://%s:%d", testSvcIP, httpPort)
 		}
-
 		appHttpHealth.Spec.Target = target
 
 		// request
@@ -402,7 +400,6 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		} else {
 			target.Host = fmt.Sprintf("http://%s:%d", testSvcIP, httpPort)
 		}
-
 		target.BodyConfigName = &bodyConfigMapName
 		target.BodyConfigNamespace = &common.TestNameSpace
 		target.Header = []string{"Content-Type: application/json"}
@@ -504,7 +501,6 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// target
 		target := new(v1beta1.AppHttpHealthyTarget)
 		target.Method = "PATCH"
-
 		if net.ParseIP(testSvcIP).To4() == nil {
 			target.Host = fmt.Sprintf("http://[%s]:%d", testSvcIP, httpPort)
 		} else {
@@ -557,7 +553,6 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// target
 		target := new(v1beta1.AppHttpHealthyTarget)
 		target.Method = "OPTIONS"
-
 		if net.ParseIP(testSvcIP).To4() == nil {
 			target.Host = fmt.Sprintf("http://[%s]:%d", testSvcIP, httpPort)
 		} else {
@@ -662,7 +657,6 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// target
 		target := new(v1beta1.AppHttpHealthyTarget)
 		target.Method = "GET"
-
 		if net.ParseIP(testPodIPs[0]).To4() == nil {
 			target.Host = fmt.Sprintf("https://[%s]", testPodIPs[0])
 		} else {


### PR DESCRIPTION
fix #91  因为字符串 https 中 包含 http 导致 webhook 判断时 会把 https 判断为 http 
fix #92 关闭 latency 开关后，平均延时为 0 导致任务永久成功
