### PR TITLE
Fix release-v0.1 documentation site bug

### DIFF
--- a/.github/workflows/auto-nightly-ci.yaml
+++ b/.github/workflows/auto-nightly-ci.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: create an issue
         uses: dacbd/create-issue-action@v1.2.1
         with:
-          token: ${{ secrets.WELAN_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           #owner: kdoctor-io
           #repo: rocktemplae
           title: "Night CI ${{ ENV.TIMESTAMP }}: Failed"

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -113,15 +113,22 @@ jobs:
       ref: ${{ needs.get-tag.outputs.tag }}
     secrets: inherit
 
+  release-chart:
+    needs: [build-release-image, get-tag]
+    uses: ./.github/workflows/call-release-chart.yaml
+    with:
+      ref: ${{ needs.get-tag.outputs.tag }}
+    secrets: inherit
+
   create-release:
-    needs: [ release-changelog, get-tag, release-pages]
+    needs: [ release-changelog, get-tag, release-chart]
     name: create release
     runs-on: ubuntu-latest
     steps:
       - name: Download Chart Artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: ${{ needs.release-pages.outputs.artifact }}
+          name: ${{ needs.release-chart.outputs.artifact }}
           path: chart-package/
 
       - name: Download Changelog Artifact

--- a/.github/workflows/call-release-changelog.yaml
+++ b/.github/workflows/call-release-changelog.yaml
@@ -140,5 +140,5 @@ jobs:
           delete-branch: true
           base: ${{ env.DEST_BRANCH }}
           signoff: true
-          token: ${{ secrets.WELAN_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ env.PR_LABEL }}

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -1,0 +1,123 @@
+name: Call Release Chart
+
+env:
+  MERGE_BRANCH: github_pages
+  PR_LABEL: pr/robot_update
+  PR_REVIWER: weizhoublue
+  CHART_OUTPUT_PATH: output/chart/*
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+    outputs:
+      artifact:
+        description: "name of chart artifact"
+        value: chart_package_artifact
+  # --- call by manual
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'branch, tag, sha'
+        required: true
+        default: main
+
+permissions: write-all
+
+jobs:
+  package:
+    name: prepare
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ env.RUN_REF }}
+    steps:
+      - name: Get Ref
+        id: get_ref
+        run: |
+          pwd
+          ls
+          if ${{ github.event_name == 'workflow_dispatch' }}; then
+              echo "call by workflow_dispatch"
+              echo "REF=${{ github.event.inputs.ref }}" >> $GITHUB_ENV
+          elif ${{ inputs.ref != '' }}; then
+              echo "call by workflow_call"
+              echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          else
+              echo "unexpected event: ${{ github.event_name }}"
+              exit 1
+          fi
+
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ env.REF }}
+
+      - name: Install yq
+        run: |
+          YQ_VERSION=v4.33.1
+          YQ_BINARY="yq_$(uname | tr 'A-Z' 'a-z')_amd64"
+          wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}.tar.gz -O /tmp/yq.tar.gz
+          tar -xzf /tmp/yq.tar.gz -C /tmp
+          sudo mv /tmp/${YQ_BINARY} /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+          yq &>/dev/null || exit 1
+
+      - name: Build chart
+        run: |
+          make chart_package
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: chart_package_artifact
+          path: ${{ env.CHART_OUTPUT_PATH }}
+          retention-days: 1
+          if-no-files-found: error
+
+  create_pr:
+    name: Create PR
+    needs: [package]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.MERGE_BRANCH }}
+          fetch-depth: 0
+
+      ## chart
+      - name: Install Helm
+        uses: azure/setup-helm@v3.5
+
+      - name: Download Chart Artifact
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: chart_package_artifact
+          path: charts
+
+      - name: Update Chart Yaml
+        run: |
+          name=${{ github.repository }}
+          proj=${name#*/}
+          url=https://${{ github.repository_owner }}.github.io/${proj}
+          helm repo index  ./charts  --url ${url}/charts
+          mv ./charts/index.yaml ./index.yaml
+
+      # Allow auto-merge on general
+      - name: Create Pull Request
+        id: create_pr
+        uses: peter-evans/create-pull-request@v5.0.2
+        with:
+          title: "robot update chart from ${{ needs.package.outputs.REF }} to branch ${{ env.MERGE_BRANCH }} "
+          commit-message: "robot update chart from  ${{ needs.package.outputs.REF }} to branch ${{ env.MERGE_BRANCH }} "
+          branch-suffix: timestamp
+          branch: robot/update_doc
+          delete-branch: true
+          base: ${{ env.MERGE_BRANCH }}
+          signoff: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ${{ env.PR_LABEL }}
+          reviewers: ${{ env.PR_REVIWER }}

--- a/.github/workflows/call-release-pages.yaml
+++ b/.github/workflows/call-release-pages.yaml
@@ -4,7 +4,6 @@ env:
   MERGE_BRANCH: github_pages
   PR_LABEL: pr/robot_update
   PR_REVIWER: weizhoublue
-  CHART_OUTPUT_PATH: output/chart/*
 
 on:
   workflow_call:
@@ -12,10 +11,6 @@ on:
       ref:
         required: true
         type: string
-    outputs:
-      artifact:
-        description: "name of chart artifact"
-        value: chart_package_artifact
   # --- call by manual
   workflow_dispatch:
     inputs:
@@ -32,18 +27,19 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ env.RUN_REF }}
+      skip_all_job: ${{ env.SKIP_ALL_JOB }}
     steps:
       - name: Get Ref
         id: get_ref
         run: |
           pwd
           ls
-          if ${{ inputs.ref != '' }}; then
-              echo "call by workflow_call"
-              echo "RUN_REF=${{ inputs.ref }}" >> $GITHUB_ENV
-          elif ${{ github.event_name == 'workflow_dispatch' }} ; then
+          if ${{ github.event_name == 'workflow_dispatch' }}; then
               echo "call by workflow_dispatch"
-              echo "RUN_REF=${{ github.event.inputs.ref }}" >> $GITHUB_ENV
+              echo "REF=${{ github.event.inputs.ref }}" >> $GITHUB_ENV
+          elif ${{ inputs.ref != '' }}; then
+              echo "call by workflow_call"
+              echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
           else
               echo "unexpected event: ${{ github.event_name }}"
               exit 1
@@ -52,90 +48,110 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.get_ref.outputs.ref }}
+          fetch-depth: 0
+          ref: ${{ env.REF }}
 
-      - name: Build Site and chart
+      - name: Extract Version
+        id: extract
         run: |
-          make build_doc
-          make chart_package
+          if ! grep -E "^[[:space:]]*v[0-9]+.[0-9]+.[0-9]+[[:space:]]*$" VERSION &>/dev/null ; then
+            echo "not a release version, skip generating doc."
+            cat VERSION
+            echo "SKIP_ALL_JOB=true" >> $GITHUB_ENV
+            exit 0
+          fi
+          # for example v0.6.1, the build's documentation version is v0.6
+          docVersion=` cat VERSION  | tr -d ' ' | tr -d '\n' | grep -Eo "v[0-9]+\.[0-9]+" `
+          if [ -n "${docVersion}" ]; then
+              echo "the version intercepted from the branch is: ${docVersion}"
+          else
+              echo "error, failed to get version." && exit 1
+          fi
+          git checkout -f ${{ env.MERGE_BRANCH }}
+          echo "Switch to the branch:${{ env.MERGE_BRANCH }} where the document is located"
+          ls
+          if [ -e "${docVersion}" ]; then
+              echo "doc version:${docVersion} already exists, just update it."
+              echo "SET_LATEST=false" >> $GITHUB_ENV
+          else
+              echo "The doc version:${docVersion} does not exist yet, while generating the doc and set it to latest"
+              echo "SET_LATEST=true" >> $GITHUB_ENV
+          fi
+          echo "the doc version is: ${docVersion}"
+          echo "DOCS_TAG=${docVersion}" >> $GITHUB_ENV
+
+      - name: build doc site
+        id: build_doc
+        if: ${{ env.SKIP_ALL_JOB != 'true' }}
+        run: |
+          git checkout ${{ env.REF }}
+          ls
+          echo "switch to the release version branch ${{ env.REF }}"
+          pip install mkdocs==1.5.2 mike==1.1.2 mkdocs-material==9.2.8
+          git config user.email "robot@example.com"
+          git config user.name "robot"
+          cp ./docs/mkdocs.yml ./
+          if ${{ env.SET_LATEST == 'true' }} ;then
+              echo "generate doc version:${{ env.DOCS_TAG }} and set to latest."
+              mike deploy --rebase -b ${{ env.MERGE_BRANCH }} --update-aliases ${{env.DOCS_TAG }} latest
+              mike set-default -b ${{ env.MERGE_BRANCH }} latest
+          else
+              echo "the version:${{ env.DOCS_TAG }} of the doc does not need to be set to the latest."
+              mike deploy --rebase -b ${{ env.MERGE_BRANCH }} ${{ env.DOCS_TAG }}
+          fi
+          rm -rf ./site
+          rm -rf ./mkdocs.yml
+          git checkout -f  ${{ env.MERGE_BRANCH }}
+          rm -rf ./charts && rm -rf ./index.yaml && rm -rf ./changelogs
+          tar -czvf ./site.tar.gz *
+          ls
+          echo "Automatic release, offline doc site package ready"
+          echo "Push a doc version: ${{ env.DOCS_TAG }} from branch: ${{ env.REF }}, update it to latest: ${{ env.SET_LATEST }} "
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@v3.1.2
+        if: ${{ env.SKIP_ALL_JOB != 'true' }}
         with:
           name: site_artifact
-          path: output/docs/site.tar.gz
+          path: site.tar.gz
           retention-days: 0
-          if-no-files-found: error
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v3.1.1
-        with:
-          name: chart_package_artifact
-          path: ${{ env.CHART_OUTPUT_PATH }}
-          retention-days: 1
           if-no-files-found: error
 
   create_pr:
     name: Create PR
     needs: [package]
+    if: ${{ needs.package.outputs.skip_all_job != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
           ref: ${{ env.MERGE_BRANCH }}
+          fetch-depth: 0
 
       ## doc
-      - name: Prepare
-        run: |
-          # prepare directory
-          [ ! -d "docs/charts" ] || mv docs/charts charts
-          rm -rf docs || true
-          mkdir docs
-
       - name: Download Artifact
         uses: actions/download-artifact@v3.0.2
         with:
           name: site_artifact
-          path: docs
 
       - name: Untar Doc
         run: |
-          cd docs
           tar -xzvf site.tar.gz
           rm -f site.tar.gz
 
-      ## chart
-      - name: Install Helm
-        uses: azure/setup-helm@v3.5
-
-      - name: Download Chart Artifact
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: chart_package_artifact
-          path: charts/
-
-      - name: Update Chart Yaml
-        run: |
-          mv charts docs/charts
-          name=${{ github.repository }}
-          proj=${name#*/}
-          url=https://${{ github.repository_owner }}.github.io/${proj}
-          cd docs
-          helm repo index  ./charts  --url ${url}/charts
-          mv ./charts/index.yaml ./index.yaml
-
-      # https://github.com/peter-evans/create-pull-request
+      # Allow auto-merge on general
       - name: Create Pull Request
         id: create_pr
         uses: peter-evans/create-pull-request@v5.0.2
         with:
-          title: "robot Update doc from ${{ needs.prepare_doc.outputs.ref }} to branch ${{ env.MERGE_BRANCH }} "
-          commit-message: "robot Update chart from ${{ needs.prepare_doc.outputs.ref }} to branch ${{ env.MERGE_BRANCH }} "
+          title: "robot update website from ${{ needs.package.outputs.REF }} to branch ${{ env.MERGE_BRANCH }} "
+          commit-message: "robot update website from  ${{ needs.package.outputs.REF }} to branch ${{ env.MERGE_BRANCH }} "
           branch-suffix: timestamp
           branch: robot/update_doc
           delete-branch: true
           base: ${{ env.MERGE_BRANCH }}
           signoff: true
-          token: ${{ secrets.WELAN_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ env.PR_LABEL }}
+          reviewers: ${{ env.PR_REVIWER }}

--- a/docs/README-zh_CN.md
+++ b/docs/README-zh_CN.md
@@ -1,0 +1,40 @@
+# kdoctor
+[![Auto Release Version](https://github.com/kdoctor-io/kdoctor/actions/workflows/auto-release.yaml/badge.svg)](https://github.com/kdoctor-io/kdoctor/actions/workflows/auto-release.yaml)
+[![Auto Nightly CI](https://github.com/kdoctor-io/kdoctor/actions/workflows/auto-nightly-ci.yaml/badge.svg)](https://github.com/kdoctor-io/kdoctor/actions/workflows/auto-nightly-ci.yaml)
+[![codecov](https://codecov.io/gh/kdoctor-io/kdoctor/branch/main/graph/badge.svg?token=rLmsuiBLM2)](https://codecov.io/gh/kdoctor-io/kdoctor)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kdoctor-io/kdoctor)](https://goreportcard.com/report/github.com/kdoctor-io/kdoctor)
+[![CodeFactor](https://www.codefactor.io/repository/github/kdoctor-io/kdoctor/badge)](https://www.codefactor.io/repository/github/kdoctor-io/kdoctor)
+
+***
+
+**简体中文** | [**English**](./README.md)
+
+## Introduction
+
+kdoctor 是一个 kubernetes 数据面测试项目，通过压力注入的方式，实现对集群进行功能、性能的主动式巡检。
+
+传统的集群巡检，通过采集指标、日志、应用状态等信息来确认集群和应用的状态，实现被动式巡检。但是在一些特殊场景下，这种方式可能不能实现预期的巡检目的、时效性、集群范围，运维人员就需要采用手动方式给集群注入一些压力，进行主动式巡检，当集群规模很大、巡检频率高或巡检流程复杂时，手工方式难以持久实施。这些场景包括：
+
+* 部署大规模集群后，希望确认所有节点间 POD 的网络连通性，避免某个节点存在网络故障，发现网络中是否存在偶发丢包问题，而通信渠道非常多，包括 pod IP、clusterIP、nodePort、loadbalancer ip、ingress ip, 甚至是 POD 多网卡、双栈IP
+
+* 希望主动检测所有节点间上的 POD 能够正常访问 coredns 服务，希望确认 coredns 服务的资源配置和副本数量正确，其服务性能能欧支持预期的最大访问量
+
+* 磁盘是易耗品，例如 etcd 等应用对磁盘性能是比较敏感的，在日常运维工作中，管理员希望周期地确认所有节点的本地磁盘是正常的，文件读写的吞吐量和延时是符合预期的
+
+* 给某个服务主动注入压力，它可能是镜像仓库、mysql 或者 api-server，以配合 BUG 复现，或确认服务性能
+
+kdoctor 是一个 kubernetes 数据面测试项目，来源于生产运维过程中的实践场景，通过压力注入的方式，实现对集群进行功能、性能的主动式巡检。 kdoctor 可以应用于:
+
+* 生产环境的部署检查、日常运维等场景，能避免了人工巡检的工作负担。
+
+* 能应用 E2E 测试、bug 复现、混沌测试等，减少编程工作。
+
+## 架构
+
+## 快速开始
+
+## 核心功能
+
+## License
+
+kdoctor is licensed under the Apache License, Version 2.0. See [LICENSE](./LICENSE) for the full license text.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+# kdoctor
+[![Auto Release Version](https://github.com/kdoctor-io/kdoctor/actions/workflows/auto-release.yaml/badge.svg)](https://github.com/kdoctor-io/kdoctor/actions/workflows/auto-release.yaml)
+[![Auto Nightly CI](https://github.com/kdoctor-io/kdoctor/actions/workflows/auto-nightly-ci.yaml/badge.svg)](https://github.com/kdoctor-io/kdoctor/actions/workflows/auto-nightly-ci.yaml)
+[![codecov](https://codecov.io/gh/kdoctor-io/kdoctor/branch/main/graph/badge.svg?token=rLmsuiBLM2)](https://codecov.io/gh/kdoctor-io/kdoctor)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kdoctor-io/kdoctor)](https://goreportcard.com/report/github.com/kdoctor-io/kdoctor)
+[![CodeFactor](https://www.codefactor.io/repository/github/kdoctor-io/kdoctor/badge)](https://www.codefactor.io/repository/github/kdoctor-io/kdoctor)
+
+***
+
+**English** | [**简体中文**](./README-zh_CN.md)
+
+## Introduction
+
+kdoctor is a cloud native project of data plane test. Through the pressure injection, it realizes the active inspection for the function and performance of the cluster.
+
+For the traditional operation and maintenance , the status of clusters and applications is confirmed by collecting information such as metrics, logs, and application status, 
+which could be called passive inspection. However, in some special scenarios, this method may not meet the expected purpose, timeliness, or cluster range, 
+administrators need to manually inject some pressure into the cluster and checkout the cluster status, which could be called active inspection. 
+When the cluster scale is large, or the inspection frequency is high, or the inspection process is complicated, it is hard to implement  manually. These scenarios include:
+
+* After deploying a large-scale cluster, administrators want to confirm the network connectivity between all nodes, to find out network failures on a certain 
+    node, or occasional packet loss. In addition, there are many communication ways including POD IP, clusterIP, nodePort, loadbalancerIP, ingress, or even POD multiple network interface, dual-stack IP.
+
+* It is desired to make sure that PODs on all nodes can access the coredns service, or the resource configuration and the replica number of the coredns are enough to support expected access pressure.
+
+* Disks are consumables and applications like etcd are sensitive to disk performance. In daily maintenance, administrators want to periodically confirm that local disks performance of all nodes are normal.
+
+* Actively inject pressure on a service like registry, mysql or api-server, to cooperate with BUG reproduce, or to confirm service performance
+
+kdoctor is a cloud native project of data plane test, which is derived from practices of the production operation and maintenance. Through the pressure injection, it realizes the active inspection for the function and performance of the cluster. kdoctor can be applied to scenarios:
+
+* inspection after creating new cluster, daily operation and maintenance. 
+
+* E2E testing, bug reproduction, chaos testing.
+
+## Architecture
+
+## Quick Start
+
+## Feature
+
+## License
+
+kdoctor is licensed under the Apache License, Version 2.0. See [LICENSE](./LICENSE) for the full license text.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,6 +7,7 @@ repo_url: https://github.com/kdoctor-io/kdoctor
 remote_branch: github_pages
 theme:
   name: material
+  custom_dir: docs/overrides
   # The maximum depth of the navigation tree in the sidebar
   navigation_depth: 2
   palette:
@@ -27,6 +28,10 @@ theme:
 plugins:
   - tags
   - search
+
+extra:
+  version:
+    provider: mike
 
 markdown_extensions:
   - meta
@@ -51,7 +56,7 @@ nav:
       - NetReach: reference/netreach-zh_CN.md
       - NetDns: reference/netdns-zh_CN.md
       - Report: reference/report.md
-      - Performance: reference/performance.md
+      - Performance: usage/performance.md
   - Development:
       - Release workflow: develop/release.md
       - Roadmap: develop/roadmap.md

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You're not viewing the latest version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+  </a>
+{% endblock %}

--- a/test/e2e/common/tools.go
+++ b/test/e2e/common/tools.go
@@ -9,8 +9,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/kdoctor-io/kdoctor/api/v1/agentServer/models"
-	"github.com/onsi/ginkgo/v2"
 	"io"
 	"math"
 	"net"
@@ -18,6 +16,9 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/kdoctor-io/kdoctor/api/v1/agentServer/models"
+	"github.com/onsi/ginkgo/v2"
 
 	"github.com/docker/docker/api/types"
 	docker_client "github.com/docker/docker/client"


### PR DESCRIPTION
release-v0.1 分支上原本的 mkdocs.yaml 中目录结构如下
```
nav:
  - README.md
  - Installation:
      - Installation: usage/install.md
      - Quickly Started: usage/get-started-kind.md
...
```
但是 release-v0.1（原本的bug）在 docs 目录并没有  README.md 文件，渲染为 website 后，总是报错找不到页面。本次修改中，为其添加该 md 文件。同时把 github action 的变更，也同步合入 release-v0.1 分支。