### PR TITLE
http client optimizes memory

### DIFF
--- a/pkg/loadRequest/loadHttp/http_requester.go
+++ b/pkg/loadRequest/loadHttp/http_requester.go
@@ -228,7 +228,6 @@ func (b *Work) makeRequest(c *http.Client, wg *sync.WaitGroup) {
 	var statusCode int
 	if err == nil {
 		size = resp.ContentLength
-		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 		statusCode = resp.StatusCode
 	} else {


### PR DESCRIPTION
原方法将 http body 返回丢弃到io.Discard，拷贝过程消耗内存，浪费资源。
取消 copy 过程，直接不处理 body，将 body 关闭，节约了近一半内存