### PR TITLE
fix: qps is not correct

### DIFF
--- a/pkg/agentDnsServer/appDnsServer.go
+++ b/pkg/agentDnsServer/appDnsServer.go
@@ -64,7 +64,6 @@ func SetupAppDnsServer(rootLogger *zap.Logger, tlsCert, tlsKey string) {
 				return
 			}
 		}
-
 		_ = w.WriteMsg(m)
 
 	})

--- a/pkg/k8s/apis/system/v1beta1/apphttphealthy.go
+++ b/pkg/k8s/apis/system/v1beta1/apphttphealthy.go
@@ -31,14 +31,15 @@ type AppHttpHealthyTaskDetail struct {
 }
 
 type HttpMetrics struct {
-	StartTime     metav1.Time         `json:"StartTime"`
-	EndTime       metav1.Time         `json:"EndTime"`
-	Duration      string              `json:"Duration"`
-	RequestCounts int64               `json:"RequestCounts"`
-	SuccessCounts int64               `json:"SuccessCounts"`
-	TPS           float64             `json:"TPS"`
-	Errors        map[string]int      `json:"Errors"`
-	Latencies     LatencyDistribution `json:"Latencies"`
+	StartTime             metav1.Time         `json:"StartTime"`
+	EndTime               metav1.Time         `json:"EndTime"`
+	Duration              string              `json:"Duration"`
+	RequestCounts         int64               `json:"RequestCounts"`
+	SuccessCounts         int64               `json:"SuccessCounts"`
+	TPS                   float64             `json:"TPS"`
+	Errors                map[string]int      `json:"Errors"`
+	Latencies             LatencyDistribution `json:"Latencies"`
+	ExistsNotSendRequests bool                `json:"ExistsNotSendRequests"`
 
 	// request data size
 	TotalDataSize string      `json:"TotalDataSize"`

--- a/pkg/k8s/apis/system/v1beta1/netdns.go
+++ b/pkg/k8s/apis/system/v1beta1/netdns.go
@@ -31,20 +31,20 @@ type NetDNSTaskDetail struct {
 }
 
 type DNSMetrics struct {
-	StartTime     metav1.Time         `json:"StartTime"`
-	EndTime       metav1.Time         `json:"EndTime"`
-	Duration      string              `json:"Duration"`
-	RequestCounts int64               `json:"RequestCounts"`
-	SuccessCounts int64               `json:"SuccessCounts"`
-	TPS           float64             `json:"TPS"`
-	Errors        map[string]int      `json:"Errors"`
-	Latencies     LatencyDistribution `json:"Latencies"`
-
-	TargetDomain string         `json:"TargetDomain"`
-	DNSServer    string         `json:"DNSServer"`
-	DNSMethod    string         `json:"DNSMethod"`
-	FailedCounts int64          `json:"FailedCounts"`
-	ReplyCode    map[string]int `json:"ReplyCode"`
+	StartTime             metav1.Time         `json:"StartTime"`
+	EndTime               metav1.Time         `json:"EndTime"`
+	Duration              string              `json:"Duration"`
+	RequestCounts         int64               `json:"RequestCounts"`
+	SuccessCounts         int64               `json:"SuccessCounts"`
+	TPS                   float64             `json:"TPS"`
+	Errors                map[string]int      `json:"Errors"`
+	Latencies             LatencyDistribution `json:"Latencies"`
+	ExistsNotSendRequests bool                `json:"ExistsNotSendRequests"`
+	TargetDomain          string              `json:"TargetDomain"`
+	DNSServer             string              `json:"DNSServer"`
+	DNSMethod             string              `json:"DNSMethod"`
+	FailedCounts          int64               `json:"FailedCounts"`
+	ReplyCode             map[string]int      `json:"ReplyCode"`
 }
 
 func (n *NetDNSTask) KindTask() string {

--- a/pkg/loadRequest/loadDns/dns.go
+++ b/pkg/loadRequest/loadDns/dns.go
@@ -73,22 +73,16 @@ func DnsRequest(logger *zap.Logger, reqData *DnsRequestData) (result *v1beta1.DN
 
 	w := &Work{
 		Concurrency:         config.AgentConfig.Configmap.NetdnsDefaultConcurrency,
+		RequestTimeSecond:   reqData.DurationInSecond,
 		QPS:                 reqData.Qps,
 		Timeout:             reqData.PerRequestTimeoutInMs,
 		Msg:                 new(dns.Msg).SetQuestion(reqData.TargetDomain, reqData.DnsType),
 		Protocol:            string(reqData.Protocol),
 		ServerAddr:          reqData.DnsServerAddr,
 		EnableLatencyMetric: reqData.EnableLatencyMetric,
+		Logger:              logger.Named("dns-client"),
 	}
 	w.Init()
-
-	// The monitoring task timed out
-	if duration > 0 {
-		go func() {
-			time.Sleep(duration)
-			w.Stop()
-		}()
-	}
 	logger.Sugar().Infof("begin to request %v for duration %v ", w.ServerAddr, duration.String())
 	w.Run()
 	logger.Sugar().Infof("finish all request %v for %s ", w.report.totalCount, w.ServerAddr)

--- a/pkg/loadRequest/loadDns/dns_reporter.go
+++ b/pkg/loadRequest/loadDns/dns_reporter.go
@@ -47,6 +47,8 @@ type report struct {
 	successCount   int64
 	failedCount    int64
 	ReplyCode      map[string]int
+
+	existsNotSendRequests bool
 }
 
 func newReport(results chan *result, enableLatencyMetric bool) *report {

--- a/pkg/loadRequest/loadHttp/http.go
+++ b/pkg/loadRequest/loadHttp/http.go
@@ -77,6 +77,7 @@ func HttpRequest(logger *zap.Logger, reqData *HttpRequestData) *v1beta1.HttpMetr
 
 	w := &Work{
 		Request:             req,
+		RequestTimeSecond:   reqData.RequestTimeSecond,
 		Concurrency:         config.AgentConfig.Configmap.NethttpDefaultConcurrency,
 		QPS:                 reqData.Qps,
 		Timeout:             reqData.PerRequestTimeoutMS,
@@ -88,16 +89,10 @@ func HttpRequest(logger *zap.Logger, reqData *HttpRequestData) *v1beta1.HttpMetr
 		ExpectStatusCode:    reqData.ExpectStatusCode,
 		RequestBody:         reqData.Body,
 		EnableLatencyMetric: reqData.EnableLatencyMetric,
+		Logger:              logger.Named("http-client"),
 	}
 	logger.Sugar().Infof("do http requests work=%v", w)
 	w.Init()
-
-	// The monitoring task timed out
-	go func() {
-		time.Sleep(duration)
-		w.Stop()
-	}()
-
 	logger.Sugar().Infof("begin to request %v for duration %v ", w.Request.URL, duration.String())
 	w.Run()
 	logger.Sugar().Infof("finish all request %v for %s ", w.report.totalCount, w.Request.URL)

--- a/pkg/loadRequest/loadHttp/http_reporter.go
+++ b/pkg/loadRequest/loadHttp/http_reporter.go
@@ -44,6 +44,8 @@ type report struct {
 	totalLatencies float32
 	sizeTotal      int64
 	totalCount     int64
+
+	existsNotSendRequests bool
 }
 
 func newReport(results chan *result, enableLatencyMetric bool) *report {

--- a/pkg/pluginManager/apphttphealthy/agentExecuteTask.go
+++ b/pkg/pluginManager/apphttphealthy/agentExecuteTask.go
@@ -21,15 +21,16 @@ import (
 	"strings"
 )
 
-func ParseSuccessCondition(successCondition *crd.NetSuccessCondition, metricResult *v1beta1.HttpMetrics) (failureReason string, err error) {
+func ParseSuccessCondition(successCondition *crd.NetSuccessCondition, metricResult *v1beta1.HttpMetrics) (failureReason string) {
 	switch {
 	case successCondition.SuccessRate != nil && float64(metricResult.SuccessCounts)/float64(metricResult.RequestCounts) < *(successCondition.SuccessRate):
 		failureReason = fmt.Sprintf("Success Rate %v is lower than request %v", float64(metricResult.SuccessCounts)/float64(metricResult.RequestCounts), *(successCondition.SuccessRate))
 	case successCondition.MeanAccessDelayInMs != nil && int64(metricResult.Latencies.Mean) > *(successCondition.MeanAccessDelayInMs):
 		failureReason = fmt.Sprintf("mean delay %v ms is bigger than request %v ms", metricResult.Latencies.Mean, *(successCondition.MeanAccessDelayInMs))
+	case metricResult.ExistsNotSendRequests:
+		failureReason = "There are unsent requests after the execution time has been reached"
 	default:
 		failureReason = ""
-		err = nil
 	}
 	return
 }
@@ -43,14 +44,7 @@ func SendRequestAndReport(logger *zap.Logger, targetName string, req *loadHttp.H
 	report.MeanDelay = result.Latencies.Mean
 	report.SucceedRate = float64(result.SuccessCounts) / float64(result.RequestCounts)
 
-	var err error
-	failureReason, err = ParseSuccessCondition(successCondition, result)
-	if err != nil {
-		failureReason = fmt.Sprintf("%v", err)
-		logger.Sugar().Errorf("internal error for target %v, error=%v", req.Url, err)
-		report.FailureReason = pointer.String(failureReason)
-		return
-	}
+	failureReason = ParseSuccessCondition(successCondition, result)
 
 	// generate report
 	// notice , upper case for first character of key, or else fail to parse json

--- a/pkg/pluginManager/netreach/agentExecuteTask.go
+++ b/pkg/pluginManager/netreach/agentExecuteTask.go
@@ -24,15 +24,16 @@ import (
 	runtimetype "github.com/kdoctor-io/kdoctor/pkg/types"
 )
 
-func ParseSuccessCondition(successCondition *crd.NetSuccessCondition, metricResult *v1beta1.HttpMetrics) (failureReason string, err error) {
+func ParseSuccessCondition(successCondition *crd.NetSuccessCondition, metricResult *v1beta1.HttpMetrics) (failureReason string) {
 	switch {
 	case successCondition.SuccessRate != nil && float64(metricResult.SuccessCounts)/float64(metricResult.RequestCounts) < *(successCondition.SuccessRate):
 		failureReason = fmt.Sprintf("Success Rate %v is lower than request %v", float64(metricResult.SuccessCounts)/float64(metricResult.RequestCounts), *(successCondition.SuccessRate))
 	case successCondition.MeanAccessDelayInMs != nil && int64(metricResult.Latencies.Mean) > *(successCondition.MeanAccessDelayInMs):
 		failureReason = fmt.Sprintf("mean delay %v ms is bigger than request %v ms", metricResult.Latencies.Mean, *(successCondition.MeanAccessDelayInMs))
+	case metricResult.ExistsNotSendRequests:
+		failureReason = "There are unsent requests after the execution time has been reached"
 	default:
 		failureReason = ""
-		err = nil
 	}
 	return
 }
@@ -46,14 +47,7 @@ func SendRequestAndReport(logger *zap.Logger, targetName string, req *loadHttp.H
 	report.MeanDelay = result.Latencies.Mean
 	report.SucceedRate = float64(result.SuccessCounts) / float64(result.RequestCounts)
 
-	var err error
-	failureReason, err = ParseSuccessCondition(successCondition, result)
-	if err != nil {
-		failureReason = fmt.Sprintf("%v", err)
-		logger.Sugar().Errorf("internal error for target %v, error=%v", req.Url, err)
-		report.FailureReason = pointer.String(failureReason)
-		return
-	}
+	failureReason = ParseSuccessCondition(successCondition, result)
 
 	// generate report
 	// notice , upper case for first character of key, or else fail to parse json

--- a/test/Makefile
+++ b/test/Makefile
@@ -159,8 +159,6 @@ deploy_project:
 		    HELM_OPTION+=" --set kdoctorAgent.ingress.enable=false " ; \
 		fi ; \
 		HELM_OPTION+=" --set feature.aggregateReport.enabled=true " ; \
-		HELM_OPTION+=" --set feature.nethttp_defaultConcurrency=10 " ; \
-		HELM_OPTION+=" --set feature.netdns_defaultConcurrency=10 " ; \
 		HELM_OPTION+=" --set kdoctorAgent.resources.requests.cpu=100m " ; \
 		HELM_OPTION+=" --set kdoctorAgent.resources.requests.memory=128Mi " ; \
 		HELM_OPTION+=" --set feature.aggregateReport.controller.reportHostPath=/var/run/kdoctor/controller " ; \

--- a/test/docs/NetDns.md
+++ b/test/docs/NetDns.md
@@ -1,7 +1,7 @@
 # E2E Cases for NetDns
 
-| Case ID | Title                                            | Priority | Smoke | Status |    Other    |
-|---------|--------------------------------------------------|----------|-------|--------|-------------|
-| D00001  | Successfully testing Cluster Dns Server case     | p1       |       | done   |             |
-| D00002  | Successfully testing User Define Dns server case | p1       |       | done   |             |
-
+| Case ID | Title                                                             | Priority | Smoke | Status |    Other    |
+|---------|-------------------------------------------------------------------|----------|-------|--------|-------------|
+| D00001  | Successfully testing Cluster Dns Server case                      | p1       |       | done   |             |
+| D00002  | Successfully testing User Define Dns server case                  | p1       |       | done   |             |
+| D00003  | Successfully testing User Define Dns server case use tcp protocol | p1       |       | done   |             |

--- a/test/e2e/common/tools.go
+++ b/test/e2e/common/tools.go
@@ -246,8 +246,8 @@ func CompareResult(f *frame.Framework, name, taskKind string, podIPs []string, n
 				// qps
 				expectRequestCount := float64(rs.Spec.Request.QPS * rs.Spec.Request.DurationInSecond)
 				realRequestCount := float64(m.Metrics.RequestCounts)
-				if math.Abs(realRequestCount-expectRequestCount)/expectRequestCount > 0.1 {
-					return GetResultFromReport(r), fmt.Errorf("The error in the number of requests is greater than 0.1,real request count: %d,expect request count:%d", int(realRequestCount), int(expectRequestCount))
+				if math.Abs(realRequestCount-expectRequestCount)/expectRequestCount > 0.05 {
+					return GetResultFromReport(r), fmt.Errorf("The error in the number of requests is greater than 0.05 ,real request count: %d,expect request count:%d", int(realRequestCount), int(expectRequestCount))
 				}
 				if float64(m.Metrics.SuccessCounts)/float64(m.Metrics.RequestCounts) != m.SucceedRate {
 					return GetResultFromReport(r), fmt.Errorf("succeedRate not equal")
@@ -298,8 +298,8 @@ func CompareResult(f *frame.Framework, name, taskKind string, podIPs []string, n
 				realCount := float64(m.Metrics.RequestCounts)
 				// report request count
 				reportRequestCount += m.Metrics.RequestCounts
-				if math.Abs(realCount-expectCount)/expectCount > 0.1 {
-					return GetResultFromReport(r), fmt.Errorf("The error in the number of requests is greater than 0.1,real request count: %d,expect request count:%d", int(realCount), int(expectCount))
+				if math.Abs(realCount-expectCount)/expectCount > 0.05 {
+					return GetResultFromReport(r), fmt.Errorf("The error in the number of requests is greater than 0.05 ,real request count: %d,expect request count:%d", int(realCount), int(expectCount))
 				}
 				if float64(m.Metrics.SuccessCounts)/float64(m.Metrics.RequestCounts) != m.SucceedRate {
 					return GetResultFromReport(r), fmt.Errorf("succeedRate not equal")
@@ -363,8 +363,8 @@ func CompareResult(f *frame.Framework, name, taskKind string, podIPs []string, n
 				realCount := float64(m.Metrics.RequestCounts)
 				// report request count
 				reportRequestCount += m.Metrics.RequestCounts
-				if math.Abs(realCount-expectCount)/expectCount > 0.1 {
-					return GetResultFromReport(r), fmt.Errorf("The error in the number of requests is greater than 0.1, real request count: %d,expect request count:%d ", int(realCount), int(expectCount))
+				if math.Abs(realCount-expectCount)/expectCount > 0.05 {
+					return GetResultFromReport(r), fmt.Errorf("The error in the number of requests is greater than 0.05, real request count: %d,expect request count:%d ", int(realCount), int(expectCount))
 				}
 				if float64(m.Metrics.SuccessCounts)/float64(m.Metrics.RequestCounts) != m.SucceedRate {
 					return GetResultFromReport(r), fmt.Errorf("succeedRate not equal")

--- a/test/e2e/netdns/netdns_test.go
+++ b/test/e2e/netdns/netdns_test.go
@@ -274,4 +274,71 @@ var _ = Describe("testing netDns ", Label("netDns"), func() {
 		Expect(success).NotTo(BeFalse(), "compare report and task result")
 
 	})
+
+	It("Successfully testing User Define Dns server case use tcp protocol", Label("D00003"), func() {
+		var e error
+		successRate := float64(1)
+		successMean := int64(1500)
+		crontab := "0 1"
+		netDnsName := "netdns-e2e-" + tools.RandomName()
+
+		netDns := new(v1beta1.Netdns)
+		netDns.Name = netDnsName
+
+		// agentSpec
+		agentSpec := new(v1beta1.AgentSpec)
+		agentSpec.TerminationGracePeriodMinutes = &termMin
+		netDns.Spec.AgentSpec = agentSpec
+
+		// successCondition
+		successCondition := new(v1beta1.NetSuccessCondition)
+		successCondition.SuccessRate = &successRate
+		successCondition.MeanAccessDelayInMs = &successMean
+		netDns.Spec.SuccessCondition = successCondition
+
+		// target
+		target := new(v1beta1.NetDnsTarget)
+		targetDnsUser := new(v1beta1.NetDnsTargetUserSpec)
+		targetDnsUser.Server = &testSvcIP
+		port := 53
+		targetDnsUser.Port = &port
+		target.NetDnsTargetUser = targetDnsUser
+		netDns.Spec.Target = target
+
+		// request
+		request := new(v1beta1.NetdnsRequest)
+		var perRequestTimeoutInMS = uint64(1000)
+		var qps = uint64(10)
+		var durationInSecond = uint64(10)
+		request.PerRequestTimeoutInMS = &perRequestTimeoutInMS
+		request.QPS = &qps
+		request.DurationInSecond = &durationInSecond
+		request.Domain = fmt.Sprintf(targetDomain, netDnsName)
+		protocol := "tcp"
+		request.Protocol = &protocol
+		netDns.Spec.Request = request
+
+		// Schedule
+		Schedule := new(v1beta1.SchedulePlan)
+		Schedule.Schedule = &crontab
+		Schedule.RoundNumber = 1
+		Schedule.RoundTimeoutMinute = 1
+		netDns.Spec.Schedule = Schedule
+
+		e = frame.CreateResource(netDns)
+		Expect(e).NotTo(HaveOccurred(), "create netDns resource")
+
+		e = common.CheckRuntime(frame, netDns, pluginManager.KindNameNetdns, 60)
+		Expect(e).NotTo(HaveOccurred(), "check task runtime spec")
+
+		e = common.WaitKdoctorTaskDone(frame, netDns, pluginManager.KindNameNetdns, 120)
+		Expect(e).NotTo(HaveOccurred(), "wait netDns task finish")
+
+		success, e := common.CompareResult(frame, netDnsName, pluginManager.KindNameNetdns, testPodIPs, reportNum, netDns)
+		Expect(e).NotTo(HaveOccurred(), "compare report and task")
+		Expect(success).To(BeTrue(), "compare report and task result")
+
+		e = common.CheckRuntimeDeadLine(frame, netDnsName, pluginManager.KindNameNetdns, 120)
+		Expect(e).NotTo(HaveOccurred(), "check task runtime resource delete")
+	})
 })


### PR DESCRIPTION
fix #95 

原方法：每个并发协程平均分配请求，这样会导致，请求数量大于期望的请求数量，影响结果，如期望发送 15 个请求，10 个并发协程执行，当完成 10 个请求后，剩余 5 个请求被 5 个协程分配，但剩下的 5 个协程没有被分配到 依然会去请求，影响期望结果。

现方法：将请求的数量放入一个 channel 中，每个并发协程去channel 中拿请求的许可，拿到许可才进行请求。