### PR TITLE
fix netdns success rate err

### DIFF
--- a/pkg/pluginManager/netdns/agentExecuteTask.go
+++ b/pkg/pluginManager/netdns/agentExecuteTask.go
@@ -26,8 +26,8 @@ import (
 
 func ParseSuccessCondition(successCondition *crd.NetSuccessCondition, metricResult *v1beta1.DNSMetrics) (failureReason string, err error) {
 	switch {
-	case successCondition.SuccessRate != nil && float64(metricResult.SuccessCounts)/float64(metricResult.SuccessCounts) < *(successCondition.SuccessRate):
-		failureReason = fmt.Sprintf("Success Rate %v is lower than request %v", float64(metricResult.SuccessCounts)/float64(metricResult.SuccessCounts), *(successCondition.SuccessRate))
+	case successCondition.SuccessRate != nil && float64(metricResult.SuccessCounts)/float64(metricResult.RequestCounts) < *(successCondition.SuccessRate):
+		failureReason = fmt.Sprintf("Success Rate %v is lower than request %v", float64(metricResult.SuccessCounts)/float64(metricResult.RequestCounts), *(successCondition.SuccessRate))
 	case successCondition.MeanAccessDelayInMs != nil && int64(metricResult.Latencies.Mean) > *(successCondition.MeanAccessDelayInMs):
 		failureReason = fmt.Sprintf("mean delay %v ms is bigger than request %v ms", metricResult.Latencies.Mean, *(successCondition.MeanAccessDelayInMs))
 	default:

--- a/test/e2e/common/tools.go
+++ b/test/e2e/common/tools.go
@@ -223,6 +223,9 @@ func CompareResult(f *frame.Framework, name, taskKind string, podIPs []string, n
 				if math.Abs(realRequestCount-expectRequestCount)/expectRequestCount > 0.1 {
 					return GetResultFromReport(r), fmt.Errorf("The error in the number of requests is greater than 0.1,real request count: %d,expect request count:%d", int(realRequestCount), int(expectRequestCount))
 				}
+				if float64(m.Metrics.SuccessCounts)/float64(m.Metrics.RequestCounts) != m.SucceedRate {
+					return GetResultFromReport(r), fmt.Errorf("succeedRate not equal")
+				}
 			}
 			// startTime
 			shcedule := pluginManager.NewSchedule(*rs.Spec.Schedule.Schedule)
@@ -271,6 +274,9 @@ func CompareResult(f *frame.Framework, name, taskKind string, podIPs []string, n
 				reportRequestCount += m.Metrics.RequestCounts
 				if math.Abs(realCount-expectCount)/expectCount > 0.1 {
 					return GetResultFromReport(r), fmt.Errorf("The error in the number of requests is greater than 0.1,real request count: %d,expect request count:%d", int(realCount), int(expectCount))
+				}
+				if float64(m.Metrics.SuccessCounts)/float64(m.Metrics.RequestCounts) != m.SucceedRate {
+					return GetResultFromReport(r), fmt.Errorf("succeedRate not equal")
 				}
 			}
 			// startTime
@@ -333,6 +339,9 @@ func CompareResult(f *frame.Framework, name, taskKind string, podIPs []string, n
 				reportRequestCount += m.Metrics.RequestCounts
 				if math.Abs(realCount-expectCount)/expectCount > 0.1 {
 					return GetResultFromReport(r), fmt.Errorf("The error in the number of requests is greater than 0.1, real request count: %d,expect request count:%d ", int(realCount), int(expectCount))
+				}
+				if float64(m.Metrics.SuccessCounts)/float64(m.Metrics.RequestCounts) != m.SucceedRate {
+					return GetResultFromReport(r), fmt.Errorf("succeedRate not equal")
 				}
 			}
 			// startTime


### PR DESCRIPTION
fix #227 
计算 成功率时，分母填写错误导致计算结果永远为 1