### PR TITLE
fix task timeout no report

### DIFF
--- a/pkg/pluginManager/agentTools.go
+++ b/pkg/pluginManager/agentTools.go
@@ -60,7 +60,6 @@ func (s *pluginAgentReconciler) CallPluginImplementRoundTask(logger *zap.Logger,
 			select {
 			case <-ctx.Done():
 				logger.Sugar().Errorf("plugin finished the round task, timeout, it takes %v , logger than expected %s", time.Since(startTime.Time).String(), roundDuration.String())
-				taskSucceed <- false
 				msg.RoundResult = string(plugintypes.RoundResultFail)
 				msg.FailedReason = pointer.String("implementing timeout")
 			default:

--- a/test/docs/AppHttpHealth.md
+++ b/test/docs/AppHttpHealth.md
@@ -1,18 +1,19 @@
 # E2E Cases for AppHttpHealth
 
 | Case ID | Title                                                                       | Priority | Smoke | Status |    Other    |
-|--------|-----------------------------------------------------------------------------|----------|-------|--------|-------------|
-| A00001 | Successfully http testing appHttpHealth method GET case                     | p1       |       | done   |             |
-| A00002 | Failed http testing appHttpHealth due to status code case                   | p1       |       | done   |             |
-| A00003 | Failed http testing appHttpHealth due to delay case                         | p1       |       | done   |             |
-| A00004 | Successfully https testing appHttpHealth method GET case                    | p1       |       | done   |             |
-| A00005 | Failed https testing appHttpHealth due to tls case                          | p1       |       | done   |             |
-| A00006 | Successfully http testing appHttpHealth method PUT case                     | p1       |       | done   |             |
-| A00007 | Successfully http testing appHttpHealth method POST With Body case          | p1       |       | done   |             |
-| A00008 | Successfully http testing appHttpHealth method HEAD case                    | p1       |       | done   |             |
-| A00009 | Successfully http testing appHttpHealth method PATCH case                   | p1       |       | done   |             |
-| A00010 | Successfully http testing appHttpHealth method OPTIONS case                 | p1       |       | done   |             |
-| A00011 | After QPS is specified, the number of requests meets the requirements  case | p1       |       | done   |             |
-| A00012 | Successfully http testing appHttpHealth due to success rate case            | p1       |       | done   |             |
-| A00013 | Successfully https testing appHttpHealth method GET Protocol Http2 case     | p1       |       | done   |             |
-| A00014 | Report request count equal real request count case                          | p1       |       | done   |             |
+|---------|-----------------------------------------------------------------------------|----------|-------|--------|-------------|
+| A00001  | Successfully http testing appHttpHealth method GET case                     | p1       |       | done   |             |
+| A00002  | Failed http testing appHttpHealth due to status code case                   | p1       |       | done   |             |
+| A00003  | Failed http testing appHttpHealth due to delay case                         | p1       |       | done   |             |
+| A00004  | Successfully https testing appHttpHealth method GET case                    | p1       |       | done   |             |
+| A00005  | Failed https testing appHttpHealth due to tls case                          | p1       |       | done   |             |
+| A00006  | Successfully http testing appHttpHealth method PUT case                     | p1       |       | done   |             |
+| A00007  | Successfully http testing appHttpHealth method POST With Body case          | p1       |       | done   |             |
+| A00008  | Successfully http testing appHttpHealth method HEAD case                    | p1       |       | done   |             |
+| A00009  | Successfully http testing appHttpHealth method PATCH case                   | p1       |       | done   |             |
+| A00010  | Successfully http testing appHttpHealth method OPTIONS case                 | p1       |       | done   |             |
+| A00011  | After QPS is specified, the number of requests meets the requirements  case | p1       |       | done   |             |
+| A00012  | Successfully http testing appHttpHealth due to success rate case            | p1       |       | done   |             |
+| A00013  | Successfully https testing appHttpHealth method GET Protocol Http2 case     | p1       |       | done   |             |
+| A00014  | Report request count equal real request count case                          | p1       |       | done   |             |
+| A00015  | Failed http every round testing appHttpHealth due to delay                  | p1       |       | done   |             |

--- a/test/e2e/apphttphealth/apphttphealth_test.go
+++ b/test/e2e/apphttphealth/apphttphealth_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 	var termMin = int64(1)
 
-	It("success http testing appHttpHealth method GET", Label("A00001", "A00011", "C00006", "E00002"), func() {
+	It("success http testing appHttpHealth method GET", Label("A00001", "A00011", "C00006", "E00002", "A00014"), func() {
 		var e error
 		successRate := float64(1)
 		successMean := int64(1500)
@@ -769,6 +769,68 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		success, e := common.CompareResult(frame, appHttpHealthName, pluginManager.KindNameAppHttpHealthy, testPodIPs, reportNum)
 		Expect(e).NotTo(HaveOccurred(), "compare report and task")
 		Expect(success).To(BeTrue(), "compare report and task result")
+
+		e = common.CheckRuntimeDeadLine(frame, appHttpHealthName, pluginManager.KindNameAppHttpHealthy, 120)
+		Expect(e).NotTo(HaveOccurred(), "check task runtime resource delete")
+	})
+
+	It("Failed http every round testing appHttpHealth due to delay ", Label("A00015"), func() {
+		var e error
+		successRate := float64(1)
+		successMean := int64(200)
+		crontab := "0 1"
+		appHttpHealthName := "apphttphealth-get" + tools.RandomName()
+
+		appHttpHealth := new(v1beta1.AppHttpHealthy)
+		appHttpHealth.Name = appHttpHealthName
+
+		// agentSpec
+		agentSpec := new(v1beta1.AgentSpec)
+		agentSpec.TerminationGracePeriodMinutes = &termMin
+		appHttpHealth.Spec.AgentSpec = *agentSpec
+
+		// successCondition
+		successCondition := new(v1beta1.NetSuccessCondition)
+		successCondition.SuccessRate = &successRate
+		successCondition.MeanAccessDelayInMs = &successMean
+		appHttpHealth.Spec.SuccessCondition = successCondition
+
+		// target
+		target := new(v1beta1.AppHttpHealthyTarget)
+		target.Method = "GET"
+		if net.ParseIP(testSvcIP).To4() == nil {
+			target.Host = fmt.Sprintf("http://[%s]:%d/?delay=1&task=%s", testSvcIP, httpPort, appHttpHealthName)
+		} else {
+			target.Host = fmt.Sprintf("http://%s:%d/?delay=1&task=%s", testSvcIP, httpPort, appHttpHealthName)
+		}
+		appHttpHealth.Spec.Target = target
+
+		// request
+		request := new(v1beta1.NetHttpRequest)
+		request.PerRequestTimeoutInMS = 2000
+		request.QPS = 10
+		request.DurationInSecond = 60
+		appHttpHealth.Spec.Request = request
+
+		// Schedule
+		Schedule := new(v1beta1.SchedulePlan)
+		Schedule.Schedule = &crontab
+		Schedule.RoundNumber = 1
+		Schedule.RoundTimeoutMinute = 1
+		appHttpHealth.Spec.Schedule = Schedule
+
+		e = frame.CreateResource(appHttpHealth)
+		Expect(e).NotTo(HaveOccurred(), "create appHttpHealth resource")
+
+		e = common.CheckRuntime(frame, appHttpHealth, pluginManager.KindNameAppHttpHealthy, 60)
+		Expect(e).NotTo(HaveOccurred(), "check task runtime spec")
+
+		e = common.WaitKdoctorTaskDone(frame, appHttpHealth, pluginManager.KindNameAppHttpHealthy, 120)
+		Expect(e).NotTo(HaveOccurred(), "wait appHttpHealth task finish")
+
+		success, e := common.CompareResult(frame, appHttpHealthName, pluginManager.KindNameAppHttpHealthy, testPodIPs, reportNum)
+		Expect(e).NotTo(HaveOccurred(), "compare report and task")
+		Expect(success).To(BeFalse(), "compare report and task result")
 
 		e = common.CheckRuntimeDeadLine(frame, appHttpHealthName, pluginManager.KindNameAppHttpHealthy, 120)
 		Expect(e).NotTo(HaveOccurred(), "check task runtime resource delete")


### PR DESCRIPTION
fix #241 
修复当一轮任务超时后，没有输出报告问题。
原因，当任务超时后，向 channel taskSucceed 中发送任务失败信号，但是在外层的 select 中 走入 ctx.done 的 case 中，因此没有向 channel  taskSucceed 取任务结果的操作，导致上层 卡在向 taskSucceed 输入信号处，导致后续生成报告的操作被 pending，经过分析，在超时处理时，因有 ctx 超时处理的 case，所以不需要taskSucceed发送信号与外层通讯。