### PR TITLE
increase netreach e2e timeout

### DIFF
--- a/test/e2e/netreach/netreach_test.go
+++ b/test/e2e/netreach/netreach_test.go
@@ -14,6 +14,8 @@ import (
 
 var _ = Describe("testing netReach ", Label("netReach"), func() {
 	var termMin = int64(1)
+	// 1000ms is not stable on GitHub ci, so increased to 3000ms
+	var requestTimeout = 3000
 	It("success testing netReach", Label("B00001", "C00004", "E00001"), func() {
 		var e error
 		successRate := float64(1)
@@ -54,7 +56,7 @@ var _ = Describe("testing netReach ", Label("netReach"), func() {
 
 		// request
 		request := new(v1beta1.NetHttpRequest)
-		request.PerRequestTimeoutInMS = 1000
+		request.PerRequestTimeoutInMS = requestTimeout
 		request.QPS = 10
 		request.DurationInSecond = 10
 		netReach.Spec.Request = request
@@ -118,7 +120,7 @@ var _ = Describe("testing netReach ", Label("netReach"), func() {
 
 		// request
 		request := new(v1beta1.NetHttpRequest)
-		request.PerRequestTimeoutInMS = 1000
+		request.PerRequestTimeoutInMS = requestTimeout
 		request.QPS = 10
 		request.DurationInSecond = 10
 		netReach.Spec.Request = request
@@ -180,7 +182,7 @@ var _ = Describe("testing netReach ", Label("netReach"), func() {
 
 		// request
 		request := new(v1beta1.NetHttpRequest)
-		request.PerRequestTimeoutInMS = 1000
+		request.PerRequestTimeoutInMS = requestTimeout
 		request.QPS = 10
 		request.DurationInSecond = 10
 		netReach.Spec.Request = request

--- a/test/e2e/runtime/runtime_test.go
+++ b/test/e2e/runtime/runtime_test.go
@@ -19,6 +19,7 @@ import (
 var _ = Describe("testing runtime ", Label("runtime"), func() {
 	var termMin = int64(5)
 	var replicas = int32(2)
+	var requestTimeout = 3000
 	It("Successfully testing cascading deletion with Task NetReach DaemonSet Service and Ingress ", Label("E00007"), func() {
 		var e error
 		successRate := float64(1)
@@ -60,7 +61,7 @@ var _ = Describe("testing runtime ", Label("runtime"), func() {
 
 		// request
 		request := new(v1beta1.NetHttpRequest)
-		request.PerRequestTimeoutInMS = 1000
+		request.PerRequestTimeoutInMS = requestTimeout
 		request.QPS = 10
 		request.DurationInSecond = 10
 		netReach.Spec.Request = request
@@ -125,7 +126,7 @@ var _ = Describe("testing runtime ", Label("runtime"), func() {
 
 		// request
 		request := new(v1beta1.NetHttpRequest)
-		request.PerRequestTimeoutInMS = 2000
+		request.PerRequestTimeoutInMS = requestTimeout
 		request.QPS = 10
 		request.DurationInSecond = 10
 		appHttpHealth.Spec.Request = request
@@ -282,7 +283,7 @@ var _ = Describe("testing runtime ", Label("runtime"), func() {
 
 		// request
 		request := new(v1beta1.NetHttpRequest)
-		request.PerRequestTimeoutInMS = 1000
+		request.PerRequestTimeoutInMS = requestTimeout
 		request.QPS = 10
 		request.DurationInSecond = 10
 		netReach.Spec.Request = request
@@ -349,7 +350,7 @@ var _ = Describe("testing runtime ", Label("runtime"), func() {
 
 		// request
 		request := new(v1beta1.NetHttpRequest)
-		request.PerRequestTimeoutInMS = 2000
+		request.PerRequestTimeoutInMS = requestTimeout
 		request.QPS = 10
 		request.DurationInSecond = 10
 		appHttpHealth.Spec.Request = request


### PR DESCRIPTION
fix #249 
fix #251 
fix #253 
netreach 任务超时时间为 1000ms，在 github ci 上会出现个别请求超时情况，增加超时时间为 3000ms