### PR TITLE
Optimize e2e use cases

### DIFF
--- a/pkg/pluginManager/agentManager.go
+++ b/pkg/pluginManager/agentManager.go
@@ -6,11 +6,11 @@ package pluginManager
 import (
 	"context"
 	"fmt"
-	networkingv1 "k8s.io/api/networking/v1"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8types "k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"

--- a/test/Makefile
+++ b/test/Makefile
@@ -160,7 +160,7 @@ deploy_project:
 		fi ; \
 		HELM_OPTION+=" --set feature.aggregateReport.enabled=true " ; \
 		HELM_OPTION+=" --set kdoctorAgent.resources.requests.cpu=200m " ; \
-		HELM_OPTION+=" --set kdoctorAgent.resources.requests.memory=256Mi " ; \
+        HELM_OPTION+=" --set kdoctorAgent.resources.requests.memory=256Mi " ; \
 		HELM_OPTION+=" --set feature.aggregateReport.controller.reportHostPath=/var/run/kdoctor/controller " ; \
 		HELM_OPTION+=" --set kdoctorAgent.debug.logLevel=debug --set kdoctorController.debug.logLevel=debug " ; \
 		HELM_OPTION+=" --set kdoctorAgent.prometheus.enabled=true --set kdoctorController.prometheus.enabled=true  " ; \

--- a/test/e2e/apphttphealth/apphttphealth_test.go
+++ b/test/e2e/apphttphealth/apphttphealth_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spidernet-io/e2eframework/tools"
 	"net"
+	"time"
 )
 
 var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
@@ -56,8 +57,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -120,8 +121,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -182,8 +183,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -245,8 +246,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -310,8 +311,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -372,8 +373,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -438,8 +439,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -500,8 +501,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -562,8 +563,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -624,8 +625,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -686,8 +687,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -751,8 +752,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -813,7 +814,7 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
+		request.QPS = 5
 		request.DurationInSecond = 60
 		appHttpHealth.Spec.Request = request
 
@@ -842,6 +843,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 	})
 
 	It("Successfully testing using default daemonSet  as workload with Task AppHttpHealthy ", Label("E00014"), func() {
+		// The machine performance of GitHub ci is too poor. Avoid the default agent executing multiple use cases at the same time.
+		time.Sleep(10 * time.Second)
 		var e error
 		successRate := float64(1)
 		successMean := int64(1500)
@@ -897,6 +900,8 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 	})
 
 	It("Successfully testing using default daemonSet  as workload with Task AppHttpHealthy ", Label("E00017"), func() {
+		// The machine performance of GitHub ci is too poor. Avoid the default agent executing multiple use cases at the same time.
+		time.Sleep(10 * time.Second)
 		var e error
 		successRate := float64(1)
 		successMean := int64(1500)

--- a/test/e2e/netreach/netreach_test.go
+++ b/test/e2e/netreach/netreach_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spidernet-io/e2eframework/tools"
+	"time"
 )
 
 var _ = Describe("testing netReach ", Label("netReach"), func() {
@@ -57,8 +58,8 @@ var _ = Describe("testing netReach ", Label("netReach"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		netReach.Spec.Request = request
 
 		// Schedule
@@ -86,6 +87,8 @@ var _ = Describe("testing netReach ", Label("netReach"), func() {
 	})
 
 	It("Successfully testing using default daemonSet  as workload with Task NetReach", Label("E00013"), func() {
+		// The machine performance of GitHub ci is too poor. Avoid the default agent executing multiple use cases at the same time.
+		time.Sleep(20 * time.Second)
 		var e error
 		successRate := float64(1)
 		successMean := int64(1500)
@@ -148,6 +151,8 @@ var _ = Describe("testing netReach ", Label("netReach"), func() {
 	})
 
 	It("Successfully testing using default daemonSet  as workload with more Task NetReach", Label("E00016"), func() {
+		// The machine performance of GitHub ci is too poor. Avoid the default agent executing multiple use cases at the same time.
+		time.Sleep(20 * time.Second)
 		var e error
 		successRate := float64(1)
 		successMean := int64(1500)

--- a/test/e2e/runtime/runtime_test.go
+++ b/test/e2e/runtime/runtime_test.go
@@ -62,8 +62,8 @@ var _ = Describe("testing runtime ", Label("runtime"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		netReach.Spec.Request = request
 
 		// Schedule
@@ -127,8 +127,8 @@ var _ = Describe("testing runtime ", Label("runtime"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule
@@ -284,8 +284,8 @@ var _ = Describe("testing runtime ", Label("runtime"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		netReach.Spec.Request = request
 
 		// Schedule
@@ -351,8 +351,8 @@ var _ = Describe("testing runtime ", Label("runtime"), func() {
 		// request
 		request := new(v1beta1.NetHttpRequest)
 		request.PerRequestTimeoutInMS = requestTimeout
-		request.QPS = 10
-		request.DurationInSecond = 10
+		request.QPS = 5
+		request.DurationInSecond = 5
 		appHttpHealth.Spec.Request = request
 
 		// Schedule


### PR DESCRIPTION
fix #264 
fix #266 
cpu 使用率达到了 100% 导致部分请求出现超时，降低所有用例的 qps，并将 default agent 执行的任务 分开执行。
不可以取消 agent 的 resource 限制，取消后会导致其他任务的 agent pod 无法起来