### PR TITLE
fix dns client msg date race

### DIFF
--- a/test/e2e/apphttphealth/apphttphealth_test.go
+++ b/test/e2e/apphttphealth/apphttphealth_test.go
@@ -886,6 +886,5 @@ var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), func() {
 		success, e := common.CompareResult(frame, appHttpHealthName, pluginManager.KindNameAppHttpHealthy, testPodIPs, reportNum, appHttpHealth)
 		Expect(e).NotTo(HaveOccurred(), "compare report and task")
 		Expect(success).To(BeTrue(), "compare report and task result")
-
 	})
 })


### PR DESCRIPTION
修复 dns client 发压时使用，同一个 msg 作用请求数据
dns client 通过msg中的 id 区分每一个请求，因此无法使用同一个 msg，需要每一个请求的 id 不同。
![image](https://github.com/kdoctor-io/kdoctor/assets/45119426/a29e3cb5-f52d-4de2-9d4d-b58bac400761)
