### PR TITLE
[#303]fix-Failed_to_get_the_dns_service_IP_list

### DIFF
--- a/pkg/agentDnsServer/appDnsServer.go
+++ b/pkg/agentDnsServer/appDnsServer.go
@@ -36,6 +36,12 @@ func SetupAppDnsServer(rootLogger *zap.Logger, tlsCert, tlsKey string) {
 		if err != nil {
 			logger.Sugar().Fatalf("failed get kube dns service,err: %v", err)
 		}
+
+		// If the ip address list is empty, the corresponding service does not exist or the selected label is incorrect
+		if len(dnsServiceIPs) == 0 {
+			logger.Sugar().Fatalf("failed get kube dns service: %v", "the corresponding service does not exist or the selected label is incorrect")
+		}
+
 		logger.Sugar().Infof("kube dns service %s ", dnsServiceIPs)
 		coreDnsAddr = fmt.Sprintf("%s:53", dnsServiceIPs[0])
 	}

--- a/pkg/k8ObjManager/service.go
+++ b/pkg/k8ObjManager/service.go
@@ -6,6 +6,7 @@ package k8sObjManager
 import (
 	"context"
 	"fmt"
+	"github.com/kdoctor-io/kdoctor/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -98,9 +99,11 @@ func (nm *k8sObjManager) ListServicesDnsIP(ctx context.Context) ([]string, error
 	serviceList := new(corev1.ServiceList)
 	var err error
 	var result []string
+
 	label := map[string]string{
-		"k8s-app": "kube-dns",
+		types.AgentConfig.DnsServiceSelectLabelKey: types.AgentConfig.DnsServiceSelectLabelValue,
 	}
+
 	ListOption := &client.ListOptions{
 		Namespace:     "kube-system",
 		LabelSelector: labels.SelectorFromSet(label),

--- a/pkg/types/agent_config.go
+++ b/pkg/types/agent_config.go
@@ -26,6 +26,8 @@ var AgentEnvMapping = []EnvMapping{
 	{"ENV_CLUSTER_DNS_DOMAIN", "cluster.local", &AgentConfig.ClusterDnsDomain},
 	{"ENV_LOCAL_NODE_IP", "", &AgentConfig.LocalNodeIP},
 	{"ENV_LOCAL_NODE_NAME", "", &AgentConfig.LocalNodeName},
+	{"ENV_DNS_SERVICE_SELECT_LABEL_KEY", "kubernetes.io/name", &AgentConfig.DnsServiceSelectLabelKey},
+	{"ENV_DNS_SERVICE_SELECT_LABEL_VALUE", "CoreDNS", &AgentConfig.DnsServiceSelectLabelValue},
 }
 
 type AgentConfigStruct struct {
@@ -50,6 +52,10 @@ type AgentConfigStruct struct {
 	ClusterDnsDomain string
 	LocalNodeIP      string
 	LocalNodeName    string
+
+	// dns selector label
+	DnsServiceSelectLabelKey   string
+	DnsServiceSelectLabelValue string
 
 	EnableAggregateAgentReport bool
 	DirPathAgentReport         string


### PR DESCRIPTION
1. Added the logic for determining whether the obtained DNS IP address list is empty
2. Get and set the label of the default selected DNS service through the environment variable