### PR TITLE
dns client udp connect read and write will not time out

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -189,4 +189,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/miekg/dns v1.1.50 => github.com/kdoctor-io/dns v0.0.0-20231117104519-7085dea69b40
+replace github.com/miekg/dns v1.1.50 => github.com/kdoctor-io/dns v0.0.0-20231123074630-7b2e2fc81556

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,8 @@ github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:V
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/kdoctor-io/dns v0.0.0-20231117104519-7085dea69b40 h1:AlmnjvSvhzwJR9YpV3r0k0b0g6de4infGN0fOImcaO4=
-github.com/kdoctor-io/dns v0.0.0-20231117104519-7085dea69b40/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
+github.com/kdoctor-io/dns v0.0.0-20231123074630-7b2e2fc81556 h1:5wa8cYpP1I3VMoX1WGOnDp2VmjEVgA481CIPTVNkBQE=
+github.com/kdoctor-io/dns v0.0.0-20231123074630-7b2e2fc81556/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=

--- a/pkg/loadRequest/loadHttp/http_requester.go
+++ b/pkg/loadRequest/loadHttp/http_requester.go
@@ -184,6 +184,7 @@ func (b *Work) Run() {
 	go func() {
 		c := time.After(time.Duration(b.RequestTimeSecond) * time.Second)
 		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		// The request should be sent immediately at 0 seconds
 		for i := 0; i < b.QPS; i++ {
 			b.qosTokenBucket <- struct{}{}
@@ -192,6 +193,8 @@ func (b *Work) Run() {
 		for {
 			select {
 			case <-c:
+				// Wait for the last request to return
+				time.Sleep(time.Duration(b.Timeout) * time.Millisecond)
 				// Reach request duration stop request
 				if len(b.qosTokenBucket) > 0 {
 					b.Logger.Sugar().Errorf("request finish remaining number of tokens len: %d", len(b.qosTokenBucket))

--- a/test/e2e/common/tools.go
+++ b/test/e2e/common/tools.go
@@ -887,6 +887,7 @@ func GetRuntimeResource(f *frame.Framework, resource *v1beta1.TaskResource, ingr
 	<-c
 
 	switch resource.RuntimeType {
+
 	case kdoctor_types.KindDaemonSet:
 		_, err := f.GetDaemonSet(resource.RuntimeName, TestNameSpace)
 		if !errors.IsNotFound(err) {

--- a/test/e2e/netreach/netreach_test.go
+++ b/test/e2e/netreach/netreach_test.go
@@ -14,12 +14,12 @@ import (
 
 var _ = Describe("testing netReach ", Label("netReach"), func() {
 	var termMin = int64(1)
-	// 1000ms is not stable on GitHub ci, so increased to 7000ms
-	var requestTimeout = 7000
+	// 1000ms is not stable on GitHub ci, so increased to 9000ms
+	var requestTimeout = 9000
 	It("success testing netReach", Label("B00001", "C00004", "E00001"), func() {
 		var e error
 		successRate := float64(1)
-		successMean := int64(4000)
+		successMean := int64(4500)
 		crontab := "0 1"
 		netReachName := "netreach-" + tools.RandomName()
 
@@ -89,7 +89,7 @@ var _ = Describe("testing netReach ", Label("netReach"), func() {
 	It("Successfully testing using default daemonSet  as workload with Task NetReach", Label("E00013"), func() {
 		var e error
 		successRate := float64(1)
-		successMean := int64(4000)
+		successMean := int64(4500)
 		crontab := "0 1"
 		netReachName := "netreach-" + tools.RandomName()
 
@@ -152,7 +152,7 @@ var _ = Describe("testing netReach ", Label("netReach"), func() {
 	It("Successfully testing using default daemonSet  as workload with more Task NetReach", Label("E00016"), func() {
 		var e error
 		successRate := float64(1)
-		successMean := int64(4000)
+		successMean := int64(4500)
 		crontab := "0 1"
 		netReachName := "netreach-" + tools.RandomName()
 

--- a/vendor/github.com/miekg/dns/client.go
+++ b/vendor/github.com/miekg/dns/client.go
@@ -58,8 +58,8 @@ func (co *Conn) tsigProvider() TsigProvider {
 }
 
 func (co *Conn) ShutDownReceiver() {
-	co.ShutDown <- struct{}{}
 	co.Close()
+	co.ShutDown <- struct{}{}
 	close(co.ResponseReceiver)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -320,7 +320,7 @@ github.com/mattn/go-isatty
 # github.com/matttproud/golang_protobuf_extensions v1.0.4
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/miekg/dns v1.1.50 => github.com/kdoctor-io/dns v0.0.0-20231117104519-7085dea69b40
+# github.com/miekg/dns v1.1.50 => github.com/kdoctor-io/dns v0.0.0-20231123074630-7b2e2fc81556
 ## explicit; go 1.19
 github.com/miekg/dns
 # github.com/mitchellh/copystructure v1.2.0


### PR DESCRIPTION
1.dns client 的 udp 连接不设置 write 和 read 的超时时间，当遇见响应较慢的服务时，最后的请求会超过 deadline时间，导致请求失败
2.防止最后的请求因延迟过高，无法得到返回，添加等待时间，等待最后的返回。