### PR TITLE
Add log and optimize e2e environment

### DIFF
--- a/pkg/loadRequest/loadDns/dns_requester.go
+++ b/pkg/loadRequest/loadDns/dns_requester.go
@@ -110,6 +110,7 @@ func (b *Work) Run() {
 			b.qosTokenBucket <- struct{}{}
 		}
 		requestRound++
+		b.Logger.Sugar().Debugf("send token %d times", requestRound)
 
 		b.Logger.Sugar().Debugf("request token channel len: %d", len(b.qosTokenBucket))
 		for {
@@ -133,6 +134,7 @@ func (b *Work) Run() {
 					b.qosTokenBucket <- struct{}{}
 				}
 				requestRound++
+				b.Logger.Sugar().Debugf("send token %d times", requestRound)
 			}
 		}
 	}()

--- a/pkg/loadRequest/loadHttp/http_requester.go
+++ b/pkg/loadRequest/loadHttp/http_requester.go
@@ -194,6 +194,7 @@ func (b *Work) Run() {
 			b.qosTokenBucket <- struct{}{}
 		}
 		requestRound++
+		b.Logger.Sugar().Debugf("send token %d times", requestRound)
 
 		b.Logger.Sugar().Debugf("request token channel len: %d", len(b.qosTokenBucket))
 		for {
@@ -217,6 +218,7 @@ func (b *Work) Run() {
 					b.qosTokenBucket <- struct{}{}
 				}
 				requestRound++
+				b.Logger.Sugar().Debugf("send token %d times", requestRound)
 			}
 		}
 	}()

--- a/pkg/pluginManager/netdns/agentExecuteTask.go
+++ b/pkg/pluginManager/netdns/agentExecuteTask.go
@@ -198,7 +198,7 @@ func (s *PluginNetDns) AgentExecuteTask(logger *zap.Logger, ctx context.Context,
 
 	}
 
-	var reportList []v1beta1.NetDNSTaskDetail
+	reportList := make([]v1beta1.NetDNSTaskDetail, 0, len(testTargetList))
 
 	var wg sync.WaitGroup
 	var l lock.Mutex

--- a/pkg/pluginManager/netreach/agentExecuteTask.go
+++ b/pkg/pluginManager/netreach/agentExecuteTask.go
@@ -283,7 +283,7 @@ func (s *PluginNetReach) AgentExecuteTask(logger *zap.Logger, ctx context.Contex
 	}
 
 	// ------------------------ implement for agent case and selected-pod case
-	var reportList []v1beta1.NetReachTaskDetail
+	reportList := make([]v1beta1.NetReachTaskDetail, 0, len(testTargetList))
 
 	var wg sync.WaitGroup
 	var l lock.Mutex
@@ -299,7 +299,7 @@ func (s *PluginNetReach) AgentExecuteTask(logger *zap.Logger, ctx context.Contex
 				EnableLatencyMetric: instance.Spec.Target.EnableLatencyMetric,
 			}
 			logger.Sugar().Debugf("implement test %v, request %v ", t.Name, *d)
-			failureReason, itemReport := SendRequestAndReport(logger, t.Name, d, successCondition)
+			failureReason, itemReport := SendRequestAndReport(logger.With(zap.String("url", t.Url)), t.Name, d, successCondition)
 			l.Lock()
 			if len(failureReason) > 0 {
 				finalfailureReason = fmt.Sprintf("test %v: %v", t.Name, failureReason)

--- a/test/Makefile
+++ b/test/Makefile
@@ -159,8 +159,10 @@ deploy_project:
 		    HELM_OPTION+=" --set kdoctorAgent.ingress.enable=false " ; \
 		fi ; \
 		HELM_OPTION+=" --set feature.aggregateReport.enabled=true " ; \
-  		HELM_OPTION+=" --set kdoctorAgent.resources.requests.cpu=400m " ; \
-  		HELM_OPTION+=" --set kdoctorAgent.resources.limits.cpu=1600m " ; \
+		HELM_OPTION+=" --set feature.nethttp_defaultConcurrency=10 " ; \
+		HELM_OPTION+=" --set feature.netdns_defaultConcurrency=10 " ; \
+  		HELM_OPTION+=" --set kdoctorAgent.resources.requests.cpu=500m " ; \
+  		HELM_OPTION+=" --set kdoctorAgent.resources.limits.cpu=2000m " ; \
   		HELM_OPTION+=" --set kdoctorAgent.resources.requests.memory=512Mi " ; \
   		HELM_OPTION+=" --set kdoctorAgent.resources.limits.memory=2048Mi " ; \
 		HELM_OPTION+=" --set feature.aggregateReport.controller.reportHostPath=/var/run/kdoctor/controller " ; \

--- a/test/e2e/apphttphealth/apphttphealth_test.go
+++ b/test/e2e/apphttphealth/apphttphealth_test.go
@@ -16,14 +16,14 @@ import (
 	"net"
 )
 
-var _ = Describe("testing appHttpHealth test ", Label("appHttpHealth"), Serial, func() {
+var _ = Describe("testing appHttpHealth test ", Serial, Label("appHttpHealth"), func() {
 	// 2000ms is not stable on GitHub ci, so increased to 7000ms
 	// issue : https://github.com/kdoctor-io/kdoctor/issues/222
 	// issue : https://github.com/kdoctor-io/kdoctor/issues/223
 	// issue : https://github.com/kdoctor-io/kdoctor/issues/165
 	// issue : https://github.com/kdoctor-io/kdoctor/issues/96
-	var requestTimeout = 7000
-	var successMean = int64(3000)
+	var requestTimeout = 15000
+	var successMean = int64(7000)
 	It("success http testing appHttpHealth method GET", Serial, Label("A00001", "A00011", "C00006", "E00002", "A00014", "E00017"), func() {
 		var e error
 		successRate := float64(1)


### PR DESCRIPTION
1.初始化 netreach target 数组，避免扩容耗时。
2.减少 e2e 环境 woker 避免无用 worker 消耗资源
3.添加 log 用于排障