### PR TITLE
http client decreases to one connect pool for request

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -26,11 +26,8 @@
 | `feature.enableIPv4`                                                    | enable ipv4                                                             | `true`                               |
 | `feature.enableIPv6`                                                    | enable ipv6                                                             | `true`                               |
 | `feature.netReachRequestMaxQPS`                                         | qps for kind NetReach                                                   | `20`                                 |
-| `feature.netReachMaxConcurrency`                                        | concurrency  for kind NetReach                                          | `10`                                 |
-| `feature.appHttpHealthyMaxConcurrency`                                  | concurrency  for kind AppHttpHealthy                                    | `20`                                 |
 | `feature.appHttpHealthyRequestMaxQPS`                                   | qps for kind AppHttpHealthy                                             | `100`                                |
 | `feature.netHttpDefaultRequestQPS`                                      | qps for kind NetHttp                                                    | `10`                                 |
-| `feature.netHttpDefaultMaxIdleConnsPerHost`                             | max idle connect for kind NetHttp                                       | `50`                                 |
 | `feature.netHttpDefaultRequestDurationInSecond`                         | Duration In Second for kind NetHttp                                     | `2`                                  |
 | `feature.netHttpDefaultRequestPerRequestTimeoutInMS`                    | PerRequest Timeout In MS for kind NetHttp                               | `500`                                |
 | `feature.netDnsMaxConcurrency`                                          | concurrency  for kind NetDns                                            | `20`                                 |

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -17,14 +17,11 @@ data:
     enableIPv6: {{ .Values.feature.enableIPv6 }}
     taskPollIntervalInSecond: {{ .Values.feature.taskPollIntervalInSecond }}
     netHttpDefaultRequestQPS: {{ .Values.feature.netHttpDefaultRequestQPS }}
-    netHttpDefaultMaxIdleConnsPerHost: {{ .Values.feature.netHttpDefaultMaxIdleConnsPerHost }}
     netHttpDefaultRequestDurationInSecond: {{ .Values.feature.netHttpDefaultRequestDurationInSecond }}
     netHttpDefaultRequestPerRequestTimeoutInMS: {{ .Values.feature.netHttpDefaultRequestPerRequestTimeoutInMS }}
     netDnsMaxConcurrency: {{ .Values.feature.netDnsMaxConcurrency }}
     netDnsRequestMaxQPS: {{ .Values.feature.netDnsRequestMaxQPS }}
-    netReachMaxConcurrency: {{ .Values.feature.netReachMaxConcurrency }}
     netReachRequestMaxQPS: {{ .Values.feature.netReachRequestMaxQPS }}
-    appHttpHealthyMaxConcurrency: {{ .Values.feature.appHttpHealthyMaxConcurrency }}
     appHttpHealthyRequestMaxQPS: {{ .Values.feature.appHttpHealthyRequestMaxQPS }}
     multusPodAnnotationKey: {{ .Values.feature.multusPodAnnotationKey }}
     agentDefaultTerminationGracePeriodMinutes: {{ .Values.feature.agentDefaultTerminationGracePeriodMinutes }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -41,20 +41,11 @@ feature:
   ## @param feature.netReachRequestMaxQPS qps for kind NetReach
   netReachRequestMaxQPS: 20
 
-  ## @param feature.netReachMaxConcurrency concurrency  for kind NetReach
-  netReachMaxConcurrency: 10
-
-  ## @param feature.appHttpHealthyMaxConcurrency concurrency  for kind AppHttpHealthy
-  appHttpHealthyMaxConcurrency: 20
-
   ## @param feature.appHttpHealthyRequestMaxQPS qps for kind AppHttpHealthy
   appHttpHealthyRequestMaxQPS: 100
 
   ## @param feature.netHttpDefaultRequestQPS qps for kind NetHttp
   netHttpDefaultRequestQPS: 10
-
-  ## @param feature.netHttpDefaultMaxIdleConnsPerHost max idle connect for kind NetHttp
-  netHttpDefaultMaxIdleConnsPerHost: 50
 
   ## @param feature.netHttpDefaultRequestDurationInSecond Duration In Second for kind NetHttp
   netHttpDefaultRequestDurationInSecond: 2

--- a/pkg/loadRequest/loadHttp/http.go
+++ b/pkg/loadRequest/loadHttp/http.go
@@ -50,7 +50,6 @@ type HttpRequestData struct {
 	Method              HttpMethod
 	Url                 string
 	Qps                 int
-	Workers             int
 	PerRequestTimeoutMS int
 	RequestTimeSecond   int
 	Header              map[string]string
@@ -73,12 +72,9 @@ func HttpRequest(logger *zap.Logger, reqData *HttpRequestData) *v1beta1.HttpMetr
 		req.Header.Set(k, v)
 	}
 
-	logger.Sugar().Infof("http request Concurrency=%d", reqData.Workers)
-
 	w := &Work{
 		Request:             req,
 		RequestTimeSecond:   reqData.RequestTimeSecond,
-		Concurrency:         reqData.Workers,
 		QPS:                 reqData.Qps,
 		Timeout:             reqData.PerRequestTimeoutMS,
 		DisableCompression:  reqData.DisableCompression,

--- a/pkg/loadRequest/loadHttp/http_requester.go
+++ b/pkg/loadRequest/loadHttp/http_requester.go
@@ -38,7 +38,6 @@ import (
 	"time"
 
 	"github.com/kdoctor-io/kdoctor/pkg/k8s/apis/system/v1beta1"
-	config "github.com/kdoctor-io/kdoctor/pkg/types"
 	"github.com/kdoctor-io/kdoctor/pkg/utils/stats"
 	"go.uber.org/zap"
 
@@ -103,9 +102,6 @@ type Work struct {
 	// Request and RequestData are cloned for each request.
 	RequestFunc func() *http.Request
 
-	// Concurrency is the concurrency level, the number of concurrent workers to run.
-	Concurrency int
-
 	// Http2 is an option to make HTTP/2 requests
 	Http2 bool
 
@@ -158,7 +154,7 @@ type Work struct {
 func (b *Work) Init() {
 	b.initOnce.Do(func() {
 		b.results = make(chan *result, MaxResultChannelSize)
-		b.stopCh = make(chan struct{}, b.Concurrency)
+		b.stopCh = make(chan struct{}, 1)
 		b.qosTokenBucket = make(chan struct{}, b.QPS)
 	})
 }
@@ -217,15 +213,13 @@ func (b *Work) Run() {
 			}
 		}
 	}()
-	b.runWorkers()
+	b.runWorker()
 	b.Finish()
 }
 
 func (b *Work) Stop() {
 	// Send stop signal so that workers can stop gracefully.
-	for i := 0; i < b.Concurrency; i++ {
-		b.stopCh <- struct{}{}
-	}
+	b.stopCh <- struct{}{}
 }
 
 func (b *Work) Finish() {
@@ -281,7 +275,7 @@ func (b *Work) runWorker() {
 			InsecureSkipVerify: true,
 			ServerName:         b.Request.Host,
 		},
-		MaxIdleConnsPerHost: config.AgentConfig.Configmap.NetHttpDefaultMaxIdleConnsPerHost,
+		MaxIdleConnsPerHost: b.QPS,
 		DisableCompression:  b.DisableCompression,
 		DisableKeepAlives:   b.DisableKeepAlives,
 		Proxy:               http.ProxyURL(b.ProxyAddr),
@@ -318,18 +312,6 @@ func (b *Work) runWorker() {
 			go b.makeRequest(client, wg)
 		}
 	}
-}
-
-func (b *Work) runWorkers() {
-	var wg sync.WaitGroup
-	wg.Add(b.Concurrency)
-	for i := 0; i < b.Concurrency; i++ {
-		go func() {
-			b.runWorker()
-			wg.Done()
-		}()
-	}
-	wg.Wait()
 
 }
 

--- a/pkg/loadRequest/loadHttp/http_test.go
+++ b/pkg/loadRequest/loadHttp/http_test.go
@@ -25,7 +25,6 @@ var _ = Describe("test http ", Label("http"), func() {
 			PerRequestTimeoutMS: 10000,
 			RequestTimeSecond:   10,
 			Qps:                 10,
-			Workers:             10,
 			Header:              header,
 		}
 		log := logger.NewStdoutLogger("debug", "test")
@@ -52,7 +51,6 @@ var _ = Describe("test http ", Label("http"), func() {
 			RequestTimeSecond:   10,
 			EnableLatencyMetric: true,
 			Qps:                 10,
-			Workers:             10,
 			Header:              header,
 		}
 		log := logger.NewStdoutLogger("debug", "test")

--- a/pkg/pluginManager/apphttphealthy/agentExecuteTask.go
+++ b/pkg/pluginManager/apphttphealthy/agentExecuteTask.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kdoctor-io/kdoctor/pkg/pluginManager/types"
 	"github.com/kdoctor-io/kdoctor/pkg/resource"
 	"github.com/kdoctor-io/kdoctor/pkg/runningTask"
-	config "github.com/kdoctor-io/kdoctor/pkg/types"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
@@ -93,13 +92,6 @@ func (s *PluginAppHttpHealthy) AgentExecuteTask(logger *zap.Logger, ctx context.
 	request := instance.Spec.Request
 	successCondition := instance.Spec.SuccessCondition
 
-	var workers int
-	if request.QPS > config.AgentConfig.Configmap.AppHttpHealthyMaxConcurrency {
-		workers = config.AgentConfig.Configmap.AppHttpHealthyMaxConcurrency
-	} else {
-		workers = request.QPS
-	}
-
 	logger.Sugar().Infof("load test custom target: Method=%v, Url=%v , qps=%v, PerRequestTimeout=%vs, Duration=%vs", target.Method, target.Host, request.QPS, request.PerRequestTimeoutInMS, request.DurationInSecond)
 	task.TargetType = "HttpAppHealthy"
 	task.TargetNumber = 1
@@ -107,7 +99,6 @@ func (s *PluginAppHttpHealthy) AgentExecuteTask(logger *zap.Logger, ctx context.
 		Method:              loadHttp.HttpMethod(target.Method),
 		Url:                 target.Host,
 		Qps:                 request.QPS,
-		Workers:             workers,
 		PerRequestTimeoutMS: request.PerRequestTimeoutInMS,
 		RequestTimeSecond:   request.DurationInSecond,
 		Http2:               target.Http2,

--- a/pkg/pluginManager/netreach/agentExecuteTask.go
+++ b/pkg/pluginManager/netreach/agentExecuteTask.go
@@ -96,13 +96,6 @@ func (s *PluginNetReach) AgentExecuteTask(logger *zap.Logger, ctx context.Contex
 	successCondition := instance.Spec.SuccessCondition
 	runtimeResource := instance.Status.Resource
 
-	var workers int
-	if request.QPS > config.AgentConfig.Configmap.NetReachMaxConcurrency {
-		workers = config.AgentConfig.Configmap.NetReachMaxConcurrency
-	} else {
-		workers = request.QPS
-	}
-
 	testTargetList := []*TestTarget{}
 
 	// test kdoctor agent
@@ -302,7 +295,6 @@ func (s *PluginNetReach) AgentExecuteTask(logger *zap.Logger, ctx context.Contex
 				Method:              t.Method,
 				Url:                 t.Url,
 				Qps:                 request.QPS,
-				Workers:             workers,
 				PerRequestTimeoutMS: request.PerRequestTimeoutInMS,
 				RequestTimeSecond:   request.DurationInSecond,
 				EnableLatencyMetric: instance.Spec.Target.EnableLatencyMetric,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,16 +9,13 @@ type ConfigmapConfig struct {
 	TaskPollIntervalInSecond int `yaml:"taskPollIntervalInSecond"`
 	// nethttp
 	NetHttpDefaultRequestQPS                   int `yaml:"netHttpDefaultRequestQPS"`
-	NetHttpDefaultMaxIdleConnsPerHost          int `yaml:"netHttpDefaultMaxIdleConnsPerHost"`
 	NetHttpDefaultRequestDurationInSecond      int `yaml:"netHttpDefaultRequestDurationInSecond"`
 	NetHttpDefaultRequestPerRequestTimeoutInMS int `yaml:"netHttpDefaultRequestPerRequestTimeoutInMS"`
 
 	// netreach
-	NetReachMaxConcurrency int `yaml:"netReachMaxConcurrency"`
-	NetReachRequestMaxQPS  int `yaml:"netReachRequestMaxQPS"`
+	NetReachRequestMaxQPS int `yaml:"netReachRequestMaxQPS"`
 	// apphttphealthy
-	AppHttpHealthyMaxConcurrency int `yaml:"appHttpHealthyMaxConcurrency"`
-	AppHttpHealthyRequestMaxQPS  int `yaml:"appHttpHealthyRequestMaxQPS"`
+	AppHttpHealthyRequestMaxQPS int `yaml:"appHttpHealthyRequestMaxQPS"`
 	// netdns
 	NetDnsMaxConcurrency int `yaml:"netDnsMaxConcurrency"`
 	NetDnsRequestMaxQPS  int `yaml:"netDnsRequestMaxQPS"`


### PR DESCRIPTION
fix #394 

http uses only one worker and one connection pool for requests, netHttpDefaultMaxIdleConnsPerHost parameter is set equal to qps, not configured in the chart