### PR TITLE
rename report name is kind + name

### DIFF
--- a/docs/usage/apphttphealthy-zh_CN.md
+++ b/docs/usage/apphttphealthy-zh_CN.md
@@ -113,15 +113,15 @@ http        true     1               1           succeed           0 1
 
 2. 查看具体任务报告
 
-    节点 kdoctor-control-plane 和节点 kdoctor-worker 上 agent 分别都执行一轮发压后，将 agent 报告聚合而成。
+    节点 kdoctor-control-plane 和节点 kdoctor-worker 上 agent 分别都执行一轮发压后，将 agent 报告聚合而成，报告名称由`${TaskKind}-${TaskName}`组成
 
     ```shell
-    kubectl get kdoctorreport http -oyaml
+    kubectl get kdoctorreport apphttphealthy-http -oyaml
     apiVersion: system.kdoctor.io/v1beta1
     kind: KdoctorReport
     metadata:
       creationTimestamp: null
-      name: http
+      name: apphttphealthy-http
     spec:
       FailedRoundNumber: null
       FinishedRoundNumber: 1

--- a/docs/usage/apphttphealthy.md
+++ b/docs/usage/apphttphealthy.md
@@ -113,15 +113,15 @@ http        true     1               1           succeed           0 1
 
 2. View specific task reports
 
-    The reports are aggregated from the agents running on both the kdoctor-control-plane node and the kdoctor-worker nodes after performing two rounds of stress testing respectively.
+    The reports are aggregated from the agents running on both the kdoctor-control-plane node and the kdoctor-worker nodes after performing two rounds of stress testing respectively,Report name consists of `${TaskKind}-${TaskName}`
 
     ```shell
-    kubectl get kdoctorreport http -oyaml
+    kubectl get kdoctorreport apphttphealthy-http -oyaml
     apiVersion: system.kdoctor.io/v1beta1
     kind: KdoctorReport
     metadata:
       creationTimestamp: null
-      name: http
+      name: apphttphealthy-http
     spec:
       FailedRoundNumber: null
       FinishedRoundNumber: 1

--- a/docs/usage/netdns-zh_CN.md
+++ b/docs/usage/netdns-zh_CN.md
@@ -115,7 +115,7 @@ netdns-cluster   true     1               1           succeed           0 1
 
 2. 查看具体任务报告
 
-    节点 kdoctor-control-plane 和节点 kdoctor-worker 上 agent 分别都执行一轮发压后，将 agent 报告聚合而成。
+    节点 kdoctor-control-plane 和节点 kdoctor-worker 上 agent 分别都执行一轮发压后，将 agent 报告聚合而成，报告名称由`${TaskKind}-${TaskName}`组成
 
     ```shell
     root@kdoctor-control-plane:/# kubectl get kdoctorreport netdns-cluster -oyaml

--- a/docs/usage/netdns.md
+++ b/docs/usage/netdns.md
@@ -64,7 +64,7 @@ cat <<EOF | kubectl apply -f -
 apiVersion: kdoctor.io/v1beta1
 kind: Netdns
 metadata:
-  name: netdns-cluster
+  name: cluster
 spec:
   expect:
     meanAccessDelayInMs: 1500
@@ -94,7 +94,7 @@ After completing a round of tasks, you can use the kdoctor aggregate API to view
 ```shell
 kubectl get netdns
 NAME             FINISH   EXPECTEDROUND   DONEROUND   LASTROUNDSTATUS   SCHEDULE
-netdns-cluster   true     1               1           succeed           0 1
+cluster           true     1               1           succeed           0 1
 ```
 
 * FINISH: indicate whether the task has been completed
@@ -115,7 +115,7 @@ netdns-cluster   true     1               1           succeed           0 1
 
 2. View specific task reports
 
-    The reports are aggregated from the agents running on both the kdoctor-control-plane node and the kdoctor-worker nodes after performing two rounds of stress testing respectively.
+    The reports are aggregated from the agents running on both the kdoctor-control-plane node and the kdoctor-worker nodes after performing two rounds of stress testing respectively,Report name consists of `${TaskKind}-${TaskName}`
 
     ```shell
     root@kdoctor-control-plane:/# kubectl get kdoctorreport netdns-cluster -oyaml
@@ -136,7 +136,7 @@ netdns-cluster   true     1               1           succeed           0 1
         RoundResult: succeed
         StartTimeStamp: "2023-08-01T09:09:39Z"
         EndTimeStamp: "2023-08-01T09:09:50Z"
-        TaskName: netdns.netdns-cluster
+        TaskName: netdns.cluster
         TaskType: Netdns
         netDNSTask:
           detail:
@@ -184,7 +184,7 @@ netdns-cluster   true     1               1           succeed           0 1
         RoundResult: succeed
         StartTimeStamp: "2023-08-01T09:09:39Z"
         EndTimeStamp: "2023-08-01T09:09:49Z"
-        TaskName: netdns.netdns-cluster
+        TaskName: netdns.cluster
         TaskType: Netdns
         netDNSTask:
           detail:
@@ -207,7 +207,7 @@ netdns-cluster   true     1               1           succeed           0 1
       ReportRoundNumber: 1
       RoundNumber: 1
       Status: Finished
-      TaskName: netdns-cluster
+      TaskName: cluster
       TaskType: Netdns
     ```
 
@@ -228,7 +228,7 @@ Below are examples of HTTP and HTTPS requests with body:
     apiVersion: kdoctor.io/v1beta1
     kind: Netdns
     metadata:
-      name: netdns- user
+      name: user
     spec:
       expect:
         meanAccessDelayInMs: 1500
@@ -253,5 +253,5 @@ Below are examples of HTTP and HTTPS requests with body:
 ## Environment Cleanup
 
 ```shell
-kubectl delete netdns netdns-cluster netdns- user
+kubectl delete netdns cluster user
 ```

--- a/docs/usage/netreach-zh_CN.md
+++ b/docs/usage/netreach-zh_CN.md
@@ -88,15 +88,15 @@ task   true     1               1           succeed           0 1
 
 2. 查看具体任务报告
 
-    节点 kdoctor-control-plane 和节点 kdoctor-worker 上 agent 分别都执行一轮互相发压后，将 agent 报告聚合而成。
+    节点 kdoctor-control-plane 和节点 kdoctor-worker 上 agent 分别都执行一轮互相发压后，将 agent 报告聚合而成，报告名称由`${TaskKind}-${TaskName}`组成。
 
     ```shell
-    root@kdoctor-control-plane:/# kubectl get kdoctorreport task -oyaml
+    root@kdoctor-control-plane:/# kubectl get kdoctorreport neteach-task -oyaml
     apiVersion: system.kdoctor.io/v1beta1
     kind: KdoctorReport
     metadata:
       creationTimestamp: null
-      name: task
+      name: neteach-task
     spec:
       FailedRoundNumber: null
       FinishedRoundNumber: 1

--- a/docs/usage/netreach.md
+++ b/docs/usage/netreach.md
@@ -29,7 +29,7 @@ Follow the [installation guide](./install.md) to install kdoctor.
 
 ### Create NetReach
 
-Create `NetReach` object that will execute a 10-second continuous task. Each agent on the nodes will use the HTTP protocol to access the IPv4 addresses of ClusterIP, Endpoint, Ingress, NodePort, and LoadBalancer immediately.
+Create `NetReach` object that will execute a 10-second continuous task. Each agent on the nodes will use the HTTP protocol to access the IPv4 addresses of ClusterIP, Endpoint, Ingress, NodePort, and LoadBalancer immediately,Report name consists of `${TaskKind}-${TaskName}`
 
 ```shell
 cat <<EOF | kubectl apply -f -
@@ -82,8 +82,8 @@ task   true     1               1           succeed           0 1
 
     ```shell
     kubectl get kdoctorreport
-    NAME   CREATED AT
-    task   0001-01-01T00:00:00Z
+    NAME           CREATED AT
+    neteach-task   0001-01-01T00:00:00Z
     ```
 
 2. View specific task reports
@@ -91,12 +91,12 @@ task   true     1               1           succeed           0 1
    The reports are aggregated from the agents running on both the kdoctor-control-plane node and the kdoctor-worker nodes after performing two rounds of stress testing respectively.
 
     ```shell
-    root@kdoctor-control-plane:/# kubectl get kdoctorreport task -oyaml
+    root@kdoctor-control-plane:/# kubectl get kdoctorreport neteach-task -oyaml
     apiVersion: system.kdoctor.io/v1beta1
     kind: KdoctorReport
     metadata:
       creationTimestamp: null
-      name: task
+      name: neteach-task
     spec:
       FailedRoundNumber: null
       FinishedRoundNumber: 1

--- a/pkg/apiserver/registry/kdoctor/kdoctorreport/etcd.go
+++ b/pkg/apiserver/registry/kdoctor/kdoctorreport/etcd.go
@@ -112,10 +112,12 @@ func (p kdoctorReportStorage) Get(ctx context.Context, key string, opts storage.
 	var taskStatus *crd.TaskStatus
 	var taskType string
 	var creationTimestamp metav1.Time
-	_, name, err := NamespaceAndNameFromKey(key, false)
+	_, taskKindName, err := NamespaceAndNameFromKey(key, false)
 	if nil != err {
 		return err
 	}
+
+	name := taskKindName[strings.Index(taskKindName, "-")+1:]
 
 	// TODO (Icarus9913): we need options to specify which CRD that we are looking for.
 	netdns, err := p.clientSet.KdoctorV1beta1().Netdnses().Get(ctx, name, metav1.GetOptions{})
@@ -214,7 +216,7 @@ func (p kdoctorReportStorage) Get(ctx context.Context, key string, opts storage.
 	}
 	kdoctorReport.Task.TaskName = name
 	kdoctorReport.Task.TaskType = taskType
-	kdoctorReport.Name = name
+	kdoctorReport.Name = strings.ToLower(taskType) + "-" + name
 	kdoctorReport.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   v1beta1.GroupName,
 		Version: v1beta1.V1betaVersion,
@@ -401,7 +403,7 @@ func (p kdoctorReportStorage) getNetDNSKdoctorReports(ctx context.Context, fileN
 		}
 
 		kdoctorReport := &v1beta1.KdoctorReport{}
-		kdoctorReport.Name = tmpNetDNS.Name
+		kdoctorReport.Name = strings.ToLower(v1beta1.NetDNSTaskName) + "-" + tmpNetDNS.Name
 		kdoctorReport.CreationTimestamp = tmpNetDNS.CreationTimestamp
 		kdoctorReport.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   v1beta1.GroupName,
@@ -474,7 +476,7 @@ func (p kdoctorReportStorage) getHttpAppHealthyReports(ctx context.Context, file
 		}
 
 		kdoctorReport := &v1beta1.KdoctorReport{}
-		kdoctorReport.Name = tmpHttpAppHealthy.Name
+		kdoctorReport.Name = strings.ToLower(v1beta1.AppHttpHealthyTaskName) + "-" + tmpHttpAppHealthy.Name
 		kdoctorReport.CreationTimestamp = tmpHttpAppHealthy.CreationTimestamp
 		kdoctorReport.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   v1beta1.GroupName,
@@ -547,7 +549,7 @@ func (p kdoctorReportStorage) getNetReachHealthyReports(ctx context.Context, fil
 		}
 
 		kdoctorReport := &v1beta1.KdoctorReport{}
-		kdoctorReport.Name = tmpNetReachHealthy.Name
+		kdoctorReport.Name = strings.ToLower(v1beta1.NetReachTaskName) + "-" + tmpNetReachHealthy.Name
 		kdoctorReport.CreationTimestamp = tmpNetReachHealthy.CreationTimestamp
 		kdoctorReport.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   v1beta1.GroupName,

--- a/test/e2e/common/tools.go
+++ b/test/e2e/common/tools.go
@@ -189,14 +189,15 @@ func CompareResult(f *frame.Framework, name, taskKind string, podIPs []string, n
 	var r *kdoctor_report.KdoctorReport
 	var err error
 	c := time.After(time.Second * 60)
-	r, err = GetPluginReportResult(f, name, n)
+	reportName := strings.ToLower(taskKind) + "-" + name
+	r, err = GetPluginReportResult(f, reportName, n)
 	for err != nil {
 		select {
 		case <-c:
 			return false, fmt.Errorf("get %s %s report time out,err: %v ", taskKind, name, err)
 		default:
 			time.Sleep(time.Second * 5)
-			r, err = GetPluginReportResult(f, name, n)
+			r, err = GetPluginReportResult(f, reportName, n)
 			break
 		}
 	}


### PR DESCRIPTION
fix #443 
The report name format is changed to kind plus name to avoid duplicate task names and duplicate report names.