### PR TITLE
change request token send interval

### DIFF
--- a/test/e2e/netdns/netdns_suite_test.go
+++ b/test/e2e/netdns/netdns_suite_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestNetReach(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "NetReach Suite")
+	RunSpecs(t, "NetDns Suite")
 }
 
 var (


### PR DESCRIPTION
fix #449 
fix #456 
Splitting qps into request tokens sent in nanoseconds increases the efficiency of link reuse and reduces resource consumption.